### PR TITLE
github: fix schema for webhook events

### DIFF
--- a/pkg/github/event.cue
+++ b/pkg/github/event.cue
@@ -5,9 +5,6 @@ package github
 Event :: {
     name: string
 
-    after:  string
-    before: string
-
     sender: {...}
     repository?: {...}
     organization?: {...}
@@ -37,6 +34,9 @@ PullRequestEvent :: {
         "unlocked" |
         "reopened" |
         "synchronize"
+
+    after?:  string
+    before?: string
 
     // The pull request number.
     number: int


### PR DESCRIPTION
`after` and `before` only appear in pull request-related events, not all events. Also, they are optional.