### PR TITLE
github: implemented comment edit in-place

### DIFF
--- a/pkg/github/comment.cue
+++ b/pkg/github/comment.cue
@@ -1,6 +1,12 @@
 package github
 
-Comment :: {
+import (
+    "blocklayer.dev/bl"
+    "encoding/json"
+    "strings"
+)
+
+CommentFields :: {
     id:   string
     body: string
 }
@@ -17,7 +23,7 @@ AddComment :: {
     body:      string
 
     data: _
-    comment: Comment
+    comment: CommentFields
     comment: data.addComment.commentEdge.node
 
     Query & {
@@ -49,7 +55,7 @@ UpdateComment :: {
     body:      string
 
     data: _
-    comment: Comment
+    comment: CommentFields
     comment: data.updateIssueComment.issueComment
 
     Query & {
@@ -69,4 +75,120 @@ UpdateComment :: {
             "body": body
         }
     }
+}
+
+Comment :: {
+    subjectId: string
+    marker: *"<!-- bl-marker-do-not-remove -->" | string
+    token: bl.Secret
+    body: string
+
+    listComments: Query & {
+        "token": token
+
+        query:
+            """
+            query($nodeId: ID!) {
+                node(id: $nodeId) {
+                    ...PullRequestParts
+                }
+            }
+            fragment PullRequestParts on PullRequest {
+                id
+                comments(first: 100) {
+                    nodes {
+                        ...CommentParts
+                    }
+                }
+            }
+            \(CommentFragment)
+            """
+        variable: {
+            nodeId: subjectId
+        }
+    }
+
+    // Contains a list of comment ID matching the marker
+    commentId: [n.id for n in listComments.data.node.comments.nodes if strings.Contains(n.body, "\(marker)")]
+
+    updateCommentQuery: json.Marshal({
+        query: """
+            mutation ($input: UpdateIssueCommentInput!) {
+                updateIssueComment(input: $input) {
+                    issueComment {
+                        ...CommentParts
+                    }
+                }
+            }
+            \(CommentFragment)
+            """
+        variables: input: {
+            if len(commentId) > 0 {
+                id: commentId[0]
+            }
+            "body": "\(body)\n\(marker)"
+        }
+    })
+
+    addCommentQuery: json.Marshal({
+        query: """
+             mutation ($input: AddCommentInput!) {
+                 addComment(input: $input) {
+                     subject {
+                         id
+                     }
+                     commentEdge {
+                         node {
+                             ...CommentParts
+                         }
+                     }
+                 }
+             }
+             \(CommentFragment)
+             """
+        variables: input: {
+            "subjectId": subjectId
+            "body": "\(body)\n\(marker)"
+        }
+    })
+
+    editComment: bl.BashScript & {
+        os: package: curl: true
+        input: {
+            "/token": token
+            if len(commentId) > 0 {
+                "/updateComment": commentId[0]
+            }
+            "/addCommentQuery": addCommentQuery
+            "/updateCommentQuery": updateCommentQuery
+            "/commentsData": listComments.response.body
+        }
+        output: {
+            "/response": string
+            "/status": string
+        }
+        code:
+            #"""
+            curlArgs=(
+                https://api.github.com/graphql
+                -L --fail --silent --show-error
+                --write-out "%{http_code}"
+                -H "Authorization: bearer $(cat /token)"
+                -H "Content-Type: application/json"
+                -X POST
+                -o /response
+            )
+
+            if [ -e /updateComment ]; then
+                curlArgs+=("-d" "$(cat /updateCommentQuery)")
+            else
+                curlArgs+=("-d" "$(cat /addCommentQuery)")
+            fi
+
+            curl "${curlArgs[@]}" > /status
+            """#
+    }
+
+    response: editComment.output["/response"]
+    status: editComment.output["/status"]
 }

--- a/pkg/github/comment.cue
+++ b/pkg/github/comment.cue
@@ -112,16 +112,7 @@ Comment :: {
     commentId: [n.id for n in listComments.data.node.comments.nodes if strings.Contains(n.body, "\(marker)")]
 
     updateCommentQuery: json.Marshal({
-        query: """
-            mutation ($input: UpdateIssueCommentInput!) {
-                updateIssueComment(input: $input) {
-                    issueComment {
-                        ...CommentParts
-                    }
-                }
-            }
-            \(CommentFragment)
-            """
+        query: UpdateComment.query
         variables: input: {
             if len(commentId) > 0 {
                 id: commentId[0]
@@ -131,21 +122,7 @@ Comment :: {
     })
 
     addCommentQuery: json.Marshal({
-        query: """
-             mutation ($input: AddCommentInput!) {
-                 addComment(input: $input) {
-                     subject {
-                         id
-                     }
-                     commentEdge {
-                         node {
-                             ...CommentParts
-                         }
-                     }
-                 }
-             }
-             \(CommentFragment)
-             """
+        query: AddComment.query
         variables: input: {
             "subjectId": subjectId
             "body": "\(body)\n\(marker)"

--- a/pkg/github/comment_test.cue
+++ b/pkg/github/comment_test.cue
@@ -41,4 +41,21 @@ TestComment: {
         **UPDATED**
         """#
     }
+
+    commentWithMarker: Comment & {
+        token: TestConfig.githubToken
+        subjectId: query.pullRequest.id
+        body:      #"""
+        ## Stackbrew Test
+
+        Edit comment in place
+
+        ```
+        \#(json.Indent(
+            json.Marshal(query.pullRequest),
+            "", "  "
+        ))
+        ```
+        """#
+    }
 }


### PR DESCRIPTION
This adds support to edit a comment in place without knowing the commentId.

It stores a marker (as html comment) in order to work.