### PR TITLE
Merge stackbrew.io and blocklayer.dev into a single cue module

### DIFF
--- a/pkg/aws/cloudformation/cloudformation.cue
+++ b/pkg/aws/cloudformation/cloudformation.cue
@@ -4,7 +4,7 @@ import (
 	"strings"
 
 	"blocklayer.dev/bl"
-	"stackbrew.io/aws"
+	"blocklayer.dev/aws"
 )
 
 // AWS CloudFormation Stack

--- a/pkg/aws/ecr/ecr.cue
+++ b/pkg/aws/ecr/ecr.cue
@@ -2,7 +2,7 @@ package ecr
 
 import (
 	"blocklayer.dev/bl"
-	"stackbrew.io/aws"
+	"blocklayer.dev/aws"
 	"encoding/base64"
 )
 

--- a/pkg/aws/ecr/ecr_test.cue
+++ b/pkg/aws/ecr/ecr_test.cue
@@ -2,7 +2,7 @@ package ecr
 
 import (
 	"blocklayer.dev/bl"
-	"stackbrew.io/aws"
+	"blocklayer.dev/aws"
 )
 
 TestConfig : {

--- a/pkg/aws/ecs/ecs.cue
+++ b/pkg/aws/ecs/ecs.cue
@@ -5,8 +5,8 @@ import (
 	"strings"
 	"encoding/json"
 
-	"stackbrew.io/aws"
-	"stackbrew.io/aws/cloudformation"
+	"blocklayer.dev/aws"
+	"blocklayer.dev/aws/cloudformation"
 )
 
 #Container: {

--- a/pkg/aws/eks/eks.cue
+++ b/pkg/aws/eks/eks.cue
@@ -2,7 +2,7 @@ package eks
 
 import (
 	"blocklayer.dev/bl"
-	"stackbrew.io/aws"
+	"blocklayer.dev/aws"
 	"encoding/base64"
 )
 

--- a/pkg/aws/eks/eks_test.cue
+++ b/pkg/aws/eks/eks_test.cue
@@ -2,8 +2,8 @@ package eks
 
 import (
 	"blocklayer.dev/bl"
-	"stackbrew.io/aws"
-	"stackbrew.io/kubernetes"
+	"blocklayer.dev/aws"
+	"blocklayer.dev/kubernetes"
 )
 
 TestConfig: {

--- a/pkg/aws/elasticbeanstalk/elasticbeanstalk.cue
+++ b/pkg/aws/elasticbeanstalk/elasticbeanstalk.cue
@@ -3,7 +3,7 @@ package elasticbeanstalk
 import (
 	"strings"
 	"blocklayer.dev/bl"
-	"stackbrew.io/aws"
+	"blocklayer.dev/aws"
 )
 
 // Elastic Beanstalk Application

--- a/pkg/aws/s3/s3.cue
+++ b/pkg/aws/s3/s3.cue
@@ -2,7 +2,7 @@ package s3
 
 import (
 	"blocklayer.dev/bl"
-	"stackbrew.io/aws"
+	"blocklayer.dev/aws"
 )
 
 // S3 file or Directory upload

--- a/pkg/bl.sum
+++ b/pkg/bl.sum
@@ -1,3 +1,0 @@
-{
-  "blocklayer.dev/bl": "sha256:21004199261ed7ce1c8e406d301a6073ce6cca3cbda7b71185b88413a00abfaf"
-}

--- a/pkg/bl/bash.cue
+++ b/pkg/bl/bash.cue
@@ -1,0 +1,51 @@
+package bl
+
+import (
+	"strings"
+)
+
+// BashScript is a helper to run bash scripts within an alpine environment.
+BashScript :: {
+	code: string
+	os: {
+		alpineVersion: "latest"
+		alpineDigest:  "sha256:ab00606a42621fb68f2ed6ad3c88be54397f981a7b70a79db3d1172b11c4367d"
+
+		package: [pkg=string]: true
+		package: bash:         true // always install bash
+		package: jq:           true // always install jq
+
+		extraCommand: [...string]
+	}
+
+	Run & {
+		fs: build.image
+		input: "/entrypoint.sh": code
+		command: [
+			"/bin/bash",
+			"--noprofile",
+			"--norc",
+			"-xeo",
+			"pipefail",
+			"/entrypoint.sh",
+		]
+	}
+
+	build: {
+		// FIXME: this should be Build &``
+		// However, this doesn't work with cue 0.0.15
+		Build
+
+		dockerfile: """
+			from alpine:\(os.alpineVersion)@\(os.alpineDigest)
+
+			\(strings.Join([
+				"run apk add -U --no-cache \(pkg)" for pkg, _ in os.package
+		], "\n"))
+
+			\(strings.Join([
+			"run \(cmd)" for cmd in os.extraCommand
+		], "\n"))
+			"""
+	}
+}

--- a/pkg/bl/bash.cue
+++ b/pkg/bl/bash.cue
@@ -39,12 +39,12 @@ BashScript :: {
 		dockerfile: """
 			from alpine:\(os.alpineVersion)@\(os.alpineDigest)
 
-			\(strings.Join([
-				"run apk add -U --no-cache \(pkg)" for pkg, _ in os.package
+			\(strings.Join([ for pkg, _ in os.package {
+				"run apk add -U --no-cache \(pkg)" }
 		], "\n"))
 
-			\(strings.Join([
-			"run \(cmd)" for cmd in os.extraCommand
+			\(strings.Join([ for cmd in os.extraCommand {
+			"run \(cmd)" }
 		], "\n"))
 			"""
 	}

--- a/pkg/bl/bl.cue
+++ b/pkg/bl/bl.cue
@@ -1,0 +1,123 @@
+package bl
+
+// Directory is a core type representing a directory.
+//
+// There are multiple implementations of directory, a directory can map to a
+// registry, to the local filesystem, and so on.
+Directory :: {
+	$bl: "bl.Directory"
+
+	// Source for the directory.
+	// FIXME: Source types should be structures rather than strings with a schema.
+	// However, disjunctions between structures is currently broken:
+	// https://github.com/cuelang/cue/issues/342
+	Registry :: =~"^registry://"
+	Context ::  =~"^context://"
+	source:     Registry | Context | Directory
+
+	path: string | *"/"
+}
+
+// Secret is a core type holding a secret value.
+//
+// Secrets are encrypted at rest and only decrypted on demand when passed as an
+// input to a Run
+Secret :: {
+	$bl:   "bl.Secret"
+	value: string
+}
+
+// Cache is a core type. It behaves like a directory but it's content is
+// persistenly cached between runs
+Cache :: {
+	$bl: "bl.Cache"
+	key: string | *""
+}
+
+// Task is the interface implemented by the core actions (Build, Run, Push).
+Task :: {
+	$bl: string
+
+	status: "completed" | "error" | "cancelled" | "cached" | "skipped"
+}
+
+// Build takes a Dockerfile and/or a build context and produces an OCI image as
+// a Directory.
+Build :: {
+	Task & {
+		$bl: "bl.Build"
+	}
+
+	// We accept either a context, a Dockerfile or both together
+	context?:    Directory
+	dockerfile?: string
+
+	// credentials for the registry (optional)
+	// used to pull images in `FROM` statements
+	auth: RegistryAuth
+
+	platform?: string | [...string]
+	buildArg?: [string]: string
+	label?: [string]:    string
+	secret?: [string]:   Secret
+
+	image: Directory
+}
+
+// Run executes `command` inside the filesystem `fs`
+Run :: {
+	Task & {
+		$bl: "bl.Run"
+	}
+
+	fs: Directory
+
+	command: string | [...string]
+	environment: [string]: string
+	workdir:   string | *"/"
+	runPolicy: *"onChange" | "always" | "never"
+
+	input: [path=string]:  Directory | string | bytes | Cache | Secret
+	output: [path=string]: Directory | string | bytes
+}
+
+// Push exports the `source` directory to the `target` registry
+Push :: {
+	Task & {
+		$bl: "bl.Push"
+	}
+
+	source: Directory
+	target: string
+
+	// credentials for the registry (optional)
+	auth: RegistryAuth
+
+	// ref will be filled in with the canonical push reference
+	ref: string
+}
+
+// Push exports the `source` directory to the `target` registry
+Pull :: {
+	Task & {
+		$bl: "bl.Pull"
+	}
+
+	// registry ref to pull
+	ref: string
+
+	// credentials for the registry (optional)
+	auth: RegistryAuth
+
+	// image will be filled with the container image
+	image: Directory
+}
+
+// RegistryCredentials encodes Docker Registry credentials
+RegistryCredentials :: {
+	username: string
+	secret:   Secret
+}
+
+// RegistryAuth maps registry hosts to credentials
+RegistryAuth :: [host=string]: RegistryCredentials

--- a/pkg/cue.mod/module.cue
+++ b/pkg/cue.mod/module.cue
@@ -1,1 +1,1 @@
-module: "stackbrew.io"
+module: "blocklayer.dev"

--- a/pkg/github/pull_request.cue
+++ b/pkg/github/pull_request.cue
@@ -1,8 +1,8 @@
 package github
 
 import (
-    "blocklayer.dev/bl"
-    "blocklayer.dev/git"
+	"blocklayer.dev/bl"
+	"blocklayer.dev/git"
 )
 
 #PullRequest: {

--- a/pkg/github/pull_request.cue
+++ b/pkg/github/pull_request.cue
@@ -1,8 +1,8 @@
 package github
 
 import (
-	"blocklayer.dev/bl"
-	"stackbrew.io/git"
+    "blocklayer.dev/bl"
+    "blocklayer.dev/git"
 )
 
 #PullRequest: {

--- a/pkg/github/query.cue
+++ b/pkg/github/query.cue
@@ -4,8 +4,8 @@ package github
 // Reference: https://developer.github.com/v4/
 
 import (
-    "blocklayer.dev/bl"
-    "blocklayer.dev/graphql"
+	"blocklayer.dev/bl"
+	"blocklayer.dev/graphql"
 )
 
 // GitHub v4 GraphQL Query

--- a/pkg/github/query.cue
+++ b/pkg/github/query.cue
@@ -4,8 +4,8 @@ package github
 // Reference: https://developer.github.com/v4/
 
 import (
-	"blocklayer.dev/bl"
-	"stackbrew.io/graphql"
+    "blocklayer.dev/bl"
+    "blocklayer.dev/graphql"
 )
 
 // GitHub v4 GraphQL Query

--- a/pkg/googlecloud/gcr/gcr.cue
+++ b/pkg/googlecloud/gcr/gcr.cue
@@ -2,7 +2,7 @@ package gcr
 
 import (
 	"blocklayer.dev/bl"
-	"stackbrew.io/googlecloud"
+	"blocklayer.dev/googlecloud"
 	"encoding/base64"
 )
 

--- a/pkg/googlecloud/gcr/gcr_test.cue
+++ b/pkg/googlecloud/gcr/gcr_test.cue
@@ -2,7 +2,7 @@ package gcr
 
 import (
 	"blocklayer.dev/bl"
-	"stackbrew.io/googlecloud"
+	"blocklayer.dev/googlecloud"
 )
 
 TestConfig : {

--- a/pkg/googlecloud/gke/gke.cue
+++ b/pkg/googlecloud/gke/gke.cue
@@ -2,7 +2,7 @@ package gke
 
 import (
 	"blocklayer.dev/bl"
-	"stackbrew.io/googlecloud"
+	"blocklayer.dev/googlecloud"
 	"encoding/base64"
 )
 

--- a/pkg/googlecloud/gke/gke_test.cue
+++ b/pkg/googlecloud/gke/gke_test.cue
@@ -2,8 +2,8 @@ package gke
 
 import (
 	"blocklayer.dev/bl"
-	"stackbrew.io/googlecloud"
-	"stackbrew.io/kubernetes"
+	"blocklayer.dev/googlecloud"
+	"blocklayer.dev/kubernetes"
 )
 
 TestConfig: {

--- a/pkg/graphql/graphql.cue
+++ b/pkg/graphql/graphql.cue
@@ -1,8 +1,8 @@
 package graphql
 
 import (
-	"encoding/json"
-	"stackbrew.io/http"
+    "encoding/json"
+    "blocklayer.dev/http"
 )
 
 #Query: {

--- a/pkg/graphql/graphql.cue
+++ b/pkg/graphql/graphql.cue
@@ -1,8 +1,8 @@
 package graphql
 
 import (
-    "encoding/json"
-    "blocklayer.dev/http"
+	"encoding/json"
+	"blocklayer.dev/http"
 )
 
 #Query: {

--- a/pkg/kubernetes/helm/helm_test.cue
+++ b/pkg/kubernetes/helm/helm_test.cue
@@ -4,8 +4,8 @@ import (
     "encoding/yaml"
 
     "blocklayer.dev/bl"
-	"stackbrew.io/aws"
-	"stackbrew.io/aws/eks"
+	"blocklayer.dev/aws"
+	"blocklayer.dev/aws/eks"
 )
 
 TestConfig: {

--- a/pkg/kubernetes/krane/krane_test.cue
+++ b/pkg/kubernetes/krane/krane_test.cue
@@ -2,9 +2,9 @@ package krane
 
 import (
 	"blocklayer.dev/bl"
-	"stackbrew.io/file"
-	"stackbrew.io/aws"
-	"stackbrew.io/aws/eks"
+	"blocklayer.dev/file"
+	"blocklayer.dev/aws"
+	"blocklayer.dev/aws/eks"
 )
 
 TestConfig: {

--- a/pkg/kubernetes/kubernetes_test.cue
+++ b/pkg/kubernetes/kubernetes_test.cue
@@ -3,8 +3,8 @@ package kubernetes
 import (
 	"blocklayer.dev/bl"
     "encoding/yaml"
-	"stackbrew.io/aws"
-	"stackbrew.io/aws/eks"
+	"blocklayer.dev/aws"
+	"blocklayer.dev/aws/eks"
 )
 
 TestConfig: {


### PR DESCRIPTION
This pull request changes the relationship between `stackbrew.io` and `blocklayer.dev`.

*Before*:

- `blocklayer.dev` is the official standard library for the Blocklayer platform. It defines low-level primitives in `blocklayer.dev/bl`
- `stackbrew.io` is a collection of high-level packages for integrating with various cloud services and tools.
- `stackbrew.io` is developed in an open-source project called Stackbrew: https://github.com/stackbrew/stackbrew
- `stackbrew.io` depends on the cue package `blocklayer.dev/bl`

*After*:

- `blocklayer.dev` is the official standard library for the Blocklayer platform. It defines both low-level primitives and high-level packages for integrating with various cloud services and tools.
- `blocklayer.dev` is developed in an open-source project called Stackbrew: https://github.com/stackbrew/stackbrew
- `blocklayer.dev` has no dependency on other cue packages
- `stackbrew.io` no longer exists.
