### PR TITLE
Convert to new-style definitions (cue 0.2)

### DIFF
--- a/pkg/aws/aws.cue
+++ b/pkg/aws/aws.cue
@@ -1,10 +1,12 @@
 package aws
 
-import "blocklayer.dev/bl"
+import ( "blocklayer.dev/bl"
 
-// AWS Config shared by all AWS packages
-Config :: {
+	// AWS Config shared by all AWS packages
+)
+
+#Config: {
 	region:    string
-	accessKey: bl.Secret
-	secretKey: bl.Secret
+	accessKey: bl.#Secret
+	secretKey: bl.#Secret
 }

--- a/pkg/aws/cloudformation/cloudformation.cue
+++ b/pkg/aws/cloudformation/cloudformation.cue
@@ -8,10 +8,10 @@ import (
 )
 
 // AWS CloudFormation Stack
-Stack :: {
+#Stack: {
 
 	// AWS Config
-	config: aws.Config
+	config: aws.#Config
 
 	// Source is the Cloudformation template, either a Cue struct or a JSON/YAML string
 	source: string
@@ -25,15 +25,15 @@ Stack :: {
 	// Output of the stack apply
 	stackOutput: run.output["/outputs/stack_output"]
 
-	run: bl.BashScript & {
+	run: bl.#BashScript & {
 		input: {
 			"/inputs/aws/access_key": config.accessKey
 			"/inputs/aws/secret_key": config.secretKey
-			"/cache/aws":             bl.Cache
+			"/cache/aws":             bl.#Cache
 			"/inputs/source":         source
 			"/inputs/stack_name":     stackName
 			if len(parameters) > 0 {
-				"/inputs/parameters": strings.Join([ for key, val in parameters { "\(key)=\(val)" } ], " ")
+				"/inputs/parameters": strings.Join([ for key, val in parameters {"\(key)=\(val)"}], " ")
 			}
 		}
 

--- a/pkg/aws/ecr/ecr.cue
+++ b/pkg/aws/ecr/ecr.cue
@@ -7,25 +7,25 @@ import (
 )
 
 // Credentials retriever for ECR
-Credentials :: {
+#Credentials: {
 
 	// AWS Config
-	config: aws.Config
+	config: aws.#Config
 
 	// Target is the ECR image
 	target: string
 
 	// ECR credentials
-	credentials: bl.RegistryCredentials & {
+	credentials: bl.#RegistryCredentials & {
 		username: output["/outputs/username"]
-		secret:   bl.Secret & {
+		secret:   bl.#Secret & {
 			// FIXME: we should be able to output a bl.Secret directly
 			value: base64.Encode(null, output["/outputs/secret"])
 		}
 	}
 
 	// Authentication for ECR Registries
-	auth: bl.RegistryAuth
+	auth: bl.#RegistryAuth
 	auth: "\(target)": credentials
 
 	helperUrl:
@@ -33,7 +33,7 @@ Credentials :: {
 
 	output: _
 
-	bl.BashScript & {
+	bl.#BashScript & {
 		runPolicy: "always"
 
 		input: {

--- a/pkg/aws/ecr/ecr_test.cue
+++ b/pkg/aws/ecr/ecr_test.cue
@@ -5,14 +5,14 @@ import (
 	"blocklayer.dev/aws"
 )
 
-TestConfig : {
-	awsConfig:     aws.Config
+TestConfig: {
+	awsConfig:     aws.#Config
 	ecrRepository: string
 }
 
 TestECR: {
 	// Generate some random
-	random: bl.BashScript & {
+	random: bl.#BashScript & {
 		runPolicy: "always"
 		code: """
 		echo -n $RANDOM > /rand
@@ -26,7 +26,7 @@ TestECR: {
 	image: "\(TestConfig.ecrRepository):test-ecr-\(rand)"
 
 	// Build a test image
-	build: bl.Build & {
+	build: bl.#Build & {
 		dockerfile: #"""
 			FROM alpine:latest@sha256:ab00606a42621fb68f2ed6ad3c88be54397f981a7b70a79db3d1172b11c4367d
 			RUN echo "\#(rand)" > /test
@@ -34,27 +34,27 @@ TestECR: {
 	}
 
 	// Get the ECR credentials
-	login: Credentials & {
+	login: #Credentials & {
 		config: TestConfig.awsConfig
 		target: image
 	}
 
 	// Push the image
-	export: bl.Push & {
-		source:      build.image
-		target:      login.target
-		auth:        login.auth
+	export: bl.#Push & {
+		source: build.image
+		target: login.target
+		auth:   login.auth
 	}
 
 	// Pull the image and verify
-	test: bl.Build & {
-		dockerfile:  #"""
+	test: bl.#Build & {
+		dockerfile: #"""
 			FROM \#(image)
 			# create a dependency between this task and export
 			RUN echo \#(export.ref)
 			RUN cat /test
 			RUN test "$(cat /test)" = "\#(rand)"
 		"""#
-		auth: login.auth
+		auth:       login.auth
 	}
 }

--- a/pkg/aws/ecs/ecs.cue
+++ b/pkg/aws/ecs/ecs.cue
@@ -9,7 +9,7 @@ import (
 	"blocklayer.dev/aws/cloudformation"
 )
 
-Container :: {
+#Container: {
 	Name:  string
 	Image: string
 	Command: [...string]
@@ -36,11 +36,11 @@ Container :: {
 	}
 }
 
-Task :: {
+#Task: {
 	cpu:         *256 | uint
 	memory:      *512 | uint
 	networkMode: *"bridge" | string
-	containers: [...Container]
+	containers: [...#Container]
 	roleArn?: string
 
 	resources: ECSTaskDefinition: {
@@ -56,9 +56,8 @@ Task :: {
 		}
 	}
 }
-
-Service :: {
-	config: aws.Config
+#Service: {
+	config: aws.#Config
 
 	// ECS cluster name or ARN
 	cluster: string
@@ -142,8 +141,8 @@ Service :: {
 }
 
 // SimpleECSApp is a simplified interface for ECS
-SimpleECSApp :: {
-	inputConfig=config:               aws.Config
+#SimpleECSApp: {
+	inputConfig=config:               aws.#Config
 	hostname:                         string
 	containerImage:                   string
 	inputContainerPort=containerPort: *80 | uint
@@ -156,8 +155,8 @@ SimpleECSApp :: {
 	out:       cfn.stackOutput
 
 	resources: {
-		(Task & {
-			containers: [Container & {
+		(#Task & {
+			containers: [#Container & {
 				Name:      subDomain
 				Image:     containerImage
 				Essential: true
@@ -168,7 +167,7 @@ SimpleECSApp :: {
 			}]
 		}).resources
 
-		(Service & {
+		(#Service & {
 			cluster:        infra.cluster
 			containerPort:  inputContainerPort
 			containerName:  subDomain
@@ -181,7 +180,7 @@ SimpleECSApp :: {
 		}).resources
 	}
 
-	cfn: cloudformation.Stack & {
+	cfn: cloudformation.#Stack & {
 		config: inputConfig
 		source: json.Marshal({
 			AWSTemplateFormatVersion: "2010-09-09"

--- a/pkg/aws/eks/eks.cue
+++ b/pkg/aws/eks/eks.cue
@@ -7,26 +7,27 @@ import (
 )
 
 // KubeConfig config outputs a valid kube-auth-config for kubectl client
-KubeConfig :: {
+
+#KubeConfig: {
 	// AWS Config
-	config: aws.Config
+	config: aws.#Config
 
 	// EKS cluster name
 	cluster: string
 
 	// kubeconfig is the generated kube configuration file
-	kubeconfig: bl.Secret & {
+	kubeconfig: bl.#Secret & {
 		// FIXME: we should be able to output a bl.Secret directly
 		value: base64.Encode(null, run.output["/outputs/kubeconfig"])
 	}
 
-	run: bl.BashScript & {
+	run: bl.#BashScript & {
 		runPolicy: "always"
 
 		input: {
 			"/inputs/access_key": config.accessKey
 			"/inputs/secret_key": config.secretKey
-			"/cache/aws":         bl.Cache
+			"/cache/aws":         bl.#Cache
 		}
 
 		output: "/outputs/kubeconfig": string

--- a/pkg/aws/eks/eks_test.cue
+++ b/pkg/aws/eks/eks_test.cue
@@ -7,13 +7,13 @@ import (
 )
 
 TestConfig: {
-	awsConfig:     aws.Config
-    eksClusterName: string
+	awsConfig:      aws.#Config
+	eksClusterName: string
 }
 
 TestEKS: {
 	// Generate some random
-	genRandom: bl.BashScript & {
+	genRandom: bl.#BashScript & {
 		runPolicy: "always"
 		code: """
 		echo -n $RANDOM > /rand
@@ -23,17 +23,17 @@ TestEKS: {
 
 	random: genRandom.output["/rand"]
 
-    // Authenticate against EKS
-    authenticate: KubeConfig & {
-        config: TestConfig.awsConfig
-        cluster: TestConfig.eksClusterName
-    }
+	// Authenticate against EKS
+	authenticate: #KubeConfig & {
+		config:  TestConfig.awsConfig
+		cluster: TestConfig.eksClusterName
+	}
 
-    // Deploy a dummy config
-    deploy: kubernetes.Apply & {
-        kubeconfig: authenticate.kubeconfig
-        namespace: "stackbrew-test"
-        source: #"""
+	// Deploy a dummy config
+	deploy: kubernetes.#Apply & {
+		kubeconfig: authenticate.kubeconfig
+		namespace:  "stackbrew-test"
+		source:     #"""
             apiVersion: v1
             kind: Pod
             metadata:
@@ -44,5 +44,5 @@ TestEKS: {
                     - name: test
                       image: hello-world
             """#
-    }
+	}
 }

--- a/pkg/aws/elasticbeanstalk/elasticbeanstalk.cue
+++ b/pkg/aws/elasticbeanstalk/elasticbeanstalk.cue
@@ -7,21 +7,21 @@ import (
 )
 
 // Elastic Beanstalk Application
-Application :: {
+#Application: {
 
 	// AWS Config
-	config: aws.Config
+	config: aws.#Config
 
 	// Beanstalk application name
 	applicationName: string
 
 	out: run.output["/outputs/out"]
 
-	run: bl.BashScript & {
+	run: bl.#BashScript & {
 		input: {
 			"/inputs/aws/access_key": config.accessKey
 			"/inputs/aws/secret_key": config.secretKey
-			"/cache/aws":             bl.Cache
+			"/cache/aws":             bl.#Cache
 		}
 
 		output: "/outputs/out": string
@@ -60,13 +60,13 @@ Application :: {
 }
 
 // Elastic Beanstalk Environment
-Environment :: {
+#Environment: {
 
 	// AWS Config
-	config: aws.Config
+	config: aws.#Config
 
 	// Source code to deploy
-	source: bl.Directory
+	source: bl.#Directory
 
 	// Beanstalk environment name
 	environmentName: string
@@ -92,13 +92,13 @@ Environment :: {
 	out:   run.output["/outputs/out"]
 	cname: strings.TrimRight(run.output["/outputs/cname"], "\n")
 
-	run: bl.BashScript & {
+	run: bl.#BashScript & {
 		runPolicy: "always"
 
 		input: {
 			"/inputs/aws/access_key": config.accessKey
 			"/inputs/aws/secret_key": config.secretKey
-			"/cache/aws":             bl.Cache
+			"/cache/aws":             bl.#Cache
 			"/inputs/source":         source
 
 			// Maps createOptions optionnally
@@ -198,13 +198,13 @@ Environment :: {
 }
 
 // Elastic Beanstalk Deployment
-Deployment :: {
+#Deployment: {
 
 	// AWS Config
-	config: aws.Config
+	config: aws.#Config
 
 	// Source code to deploy
-	source: bl.Directory
+	source: bl.#Directory
 
 	// Beanstalk environment name
 	environmentName: string
@@ -214,13 +214,13 @@ Deployment :: {
 
 	cname: strings.TrimRight(run.output["/outputs/cname"], "\n")
 
-	run: bl.BashScript & {
+	run: bl.#BashScript & {
 		runPolicy: "always"
 
 		input: {
 			"/inputs/aws/access_key": config.accessKey
 			"/inputs/aws/secret_key": config.secretKey
-			"/cache/aws":             bl.Cache
+			"/cache/aws":             bl.#Cache
 			"/inputs/source":         source
 		}
 

--- a/pkg/aws/elb/elb.cue
+++ b/pkg/aws/elb/elb.cue
@@ -9,10 +9,10 @@ import (
 )
 
 // Returns a non-taken rule priority
-NextRulePriority :: {
+#NextRulePriority: {
 
 	// AWS Config
-	config: aws.Config
+	config: aws.#Config
 
 	// ListenerArn
 	listenerArn: string
@@ -24,7 +24,7 @@ NextRulePriority :: {
 	priority: strconv.Atoi(strings.TrimRight(output["/outputs/priority"], "\n"))
 
 	output: _
-	bl.BashScript & {
+	bl.#BashScript & {
 		runPolicy: "always"
 
 		input: {
@@ -32,7 +32,7 @@ NextRulePriority :: {
 			"/inputs/aws/secret_key": config.secretKey
 			"/inputs/listenerArn":    listenerArn
 			"/inputs/vhost":          vhost
-			"/cache/aws":             bl.Cache
+			"/cache/aws":             bl.#Cache
 		}
 
 		output: "/outputs/priority": string

--- a/pkg/aws/elb/elb.cue
+++ b/pkg/aws/elb/elb.cue
@@ -5,7 +5,7 @@ import (
 	"strings"
 
 	"blocklayer.dev/bl"
-	"stackbrew.io/aws"
+	"blocklayer.dev/aws"
 )
 
 // Returns a non-taken rule priority

--- a/pkg/aws/rds/rds.cue
+++ b/pkg/aws/rds/rds.cue
@@ -5,9 +5,9 @@ import (
 	"blocklayer.dev/aws"
 )
 
-CreateDB :: {
+#CreateDB: {
 	// AWS Config
-	config: aws.Config
+	config: aws.#Config
 
 	// DB name
 	name: string
@@ -22,7 +22,7 @@ CreateDB :: {
 
 	output: _
 
-	bl.BashScript & {
+	bl.#BashScript & {
 		input: {
 			"/inputs/aws/access_key": config.accessKey
 			"/inputs/aws/secret_key": config.secretKey
@@ -70,10 +70,9 @@ CreateDB :: {
             """#
 	}
 }
-
-CreateUser :: {
+#CreateUser: {
 	// AWS Config
-	config: aws.Config
+	config: aws.#Config
 
 	// Username
 	username: string
@@ -91,7 +90,7 @@ CreateUser :: {
 
 	output: _
 
-	bl.BashScript & {
+	bl.#BashScript & {
 		input: {
 			"/inputs/aws/access_key": config.accessKey
 			"/inputs/aws/secret_key": config.secretKey

--- a/pkg/aws/rds/rds.cue
+++ b/pkg/aws/rds/rds.cue
@@ -2,7 +2,7 @@ package rds
 
 import (
 	"blocklayer.dev/bl"
-	"stackbrew.io/aws"
+	"blocklayer.dev/aws"
 )
 
 CreateDB :: {

--- a/pkg/aws/s3/s3.cue
+++ b/pkg/aws/s3/s3.cue
@@ -6,13 +6,13 @@ import (
 )
 
 // S3 file or Directory upload
-Put :: {
+#Put: {
 
 	// AWS Config
-	config: aws.Config
+	config: aws.#Config
 
 	// Source Directory, File or String to Upload to S3
-	source: string | bl.Directory
+	source: string | bl.#Directory
 
 	// Target S3 URL (eg. s3://<bucket-name>/<path>/<sub-path>)
 	target: string
@@ -20,7 +20,7 @@ Put :: {
 	// URL of the uploaded S3 object
 	url: run.output["/outputs/url"]
 
-	run: bl.BashScript & {
+	run: bl.#BashScript & {
 		runPolicy: "always"
 
 		input: {
@@ -28,7 +28,7 @@ Put :: {
 			"/inputs/aws/secret_key": config.secretKey
 			"/inputs/source":         source
 			"/inputs/target":         target
-			"/cache/aws":             bl.Cache
+			"/cache/aws":             bl.#Cache
 		}
 
 		output: "/outputs/url": string

--- a/pkg/bl/bash.cue
+++ b/pkg/bl/bash.cue
@@ -5,7 +5,7 @@ import (
 )
 
 // BashScript is a helper to run bash scripts within an alpine environment.
-BashScript :: {
+#BashScript: {
 	code: string
 	os: {
 		alpineVersion: "latest"
@@ -18,7 +18,7 @@ BashScript :: {
 		extraCommand: [...string]
 	}
 
-	Run & {
+	#Run & {
 		fs: build.image
 		input: "/entrypoint.sh": code
 		command: [
@@ -34,17 +34,19 @@ BashScript :: {
 	build: {
 		// FIXME: this should be Build &``
 		// However, this doesn't work with cue 0.0.15
-		Build
+		#Build
 
 		dockerfile: """
 			from alpine:\(os.alpineVersion)@\(os.alpineDigest)
 
 			\(strings.Join([ for pkg, _ in os.package {
-				"run apk add -U --no-cache \(pkg)" }
+			"run apk add -U --no-cache \(pkg)"
+		},
 		], "\n"))
 
 			\(strings.Join([ for cmd in os.extraCommand {
-			"run \(cmd)" }
+			"run \(cmd)"
+		},
 		], "\n"))
 			"""
 	}

--- a/pkg/bl/bl.cue
+++ b/pkg/bl/bl.cue
@@ -4,16 +4,17 @@ package bl
 //
 // There are multiple implementations of directory, a directory can map to a
 // registry, to the local filesystem, and so on.
-Directory :: {
+
+#Directory: {
 	$bl: "bl.Directory"
 
 	// Source for the directory.
 	// FIXME: Source types should be structures rather than strings with a schema.
 	// However, disjunctions between structures is currently broken:
 	// https://github.com/cuelang/cue/issues/342
-	Registry :: =~"^registry://"
-	Context ::  =~"^context://"
-	source:     Registry | Context | Directory
+	#Registry: =~"^registry://"
+	#Context:  =~"^context://"
+	source:    #Registry | #Context | #Directory
 
 	path: string | *"/"
 }
@@ -22,20 +23,21 @@ Directory :: {
 //
 // Secrets are encrypted at rest and only decrypted on demand when passed as an
 // input to a Run
-Secret :: {
+
+#Secret: {
 	$bl:   "bl.Secret"
 	value: string
 }
 
 // Cache is a core type. It behaves like a directory but it's content is
 // persistenly cached between runs
-Cache :: {
+#Cache: {
 	$bl: "bl.Cache"
 	key: string | *""
 }
 
 // Task is the interface implemented by the core actions (Build, Run, Push).
-Task :: {
+#Task: {
 	$bl: string
 
 	status: "completed" | "error" | "cancelled" | "cached" | "skipped"
@@ -43,63 +45,63 @@ Task :: {
 
 // Build takes a Dockerfile and/or a build context and produces an OCI image as
 // a Directory.
-Build :: {
-	Task & {
+#Build: {
+	#Task & {
 		$bl: "bl.Build"
 	}
 
 	// We accept either a context, a Dockerfile or both together
-	context?:    Directory
+	context?:    #Directory
 	dockerfile?: string
 
 	// credentials for the registry (optional)
 	// used to pull images in `FROM` statements
-	auth: RegistryAuth
+	auth: #RegistryAuth
 
 	platform?: string | [...string]
 	buildArg?: [string]: string
 	label?: [string]:    string
-	secret?: [string]:   Secret
+	secret?: [string]:   #Secret
 
-	image: Directory
+	image: #Directory
 }
 
 // Run executes `command` inside the filesystem `fs`
-Run :: {
-	Task & {
+#Run: {
+	#Task & {
 		$bl: "bl.Run"
 	}
 
-	fs: Directory
+	fs: #Directory
 
 	command: string | [...string]
 	environment: [string]: string
 	workdir:   string | *"/"
 	runPolicy: *"onChange" | "always" | "never"
 
-	input: [path=string]:  Directory | string | bytes | Cache | Secret
-	output: [path=string]: Directory | string | bytes
+	input: [path=string]:  #Directory | string | bytes | #Cache | #Secret
+	output: [path=string]: #Directory | string | bytes
 }
 
 // Push exports the `source` directory to the `target` registry
-Push :: {
-	Task & {
+#Push: {
+	#Task & {
 		$bl: "bl.Push"
 	}
 
-	source: Directory
+	source: #Directory
 	target: string
 
 	// credentials for the registry (optional)
-	auth: RegistryAuth
+	auth: #RegistryAuth
 
 	// ref will be filled in with the canonical push reference
 	ref: string
 }
 
 // Push exports the `source` directory to the `target` registry
-Pull :: {
-	Task & {
+#Pull: {
+	#Task & {
 		$bl: "bl.Pull"
 	}
 
@@ -107,17 +109,19 @@ Pull :: {
 	ref: string
 
 	// credentials for the registry (optional)
-	auth: RegistryAuth
+	auth: #RegistryAuth
 
 	// image will be filled with the container image
-	image: Directory
+	image: #Directory
 }
 
 // RegistryCredentials encodes Docker Registry credentials
-RegistryCredentials :: {
+#RegistryCredentials: {
 	username: string
-	secret:   Secret
+	secret:   #Secret
 }
 
 // RegistryAuth maps registry hosts to credentials
-RegistryAuth :: [host=string]: RegistryCredentials
+#RegistryAuth: {
+	[host=string]: #RegistryCredentials
+}

--- a/pkg/dockerhub/dockerhub.cue
+++ b/pkg/dockerhub/dockerhub.cue
@@ -5,24 +5,24 @@ import (
 )
 
 // Credentials retriever for Docker Hub
-Credentials :: {
+#Credentials: {
 
 	// Docker Hub Config
 	config: {
 		username: string
-		password: bl.Secret
+		password: bl.#Secret
 	}
 
 	// Target is the Docker Hub image
 	target: string
 
 	// Registry Credentials
-	credentials: bl.RegistryCredentials & {
+	credentials: bl.#RegistryCredentials & {
 		username: config.username
 		secret:   config.password
 	}
 
 	// Authentication for Docker Hub
-	auth: bl.RegistryAuth
+	auth: bl.#RegistryAuth
 	auth: "https://index.docker.io/v1/": credentials
 }

--- a/pkg/dockerhub/dockerhub_test.cue
+++ b/pkg/dockerhub/dockerhub_test.cue
@@ -4,14 +4,14 @@ import (
 	"blocklayer.dev/bl"
 )
 
-TestConfig : {
-	dockerHubConfig:     Credentials.config
+TestConfig: {
+	dockerHubConfig:     #Credentials.config
 	dockerHubRepository: string
 }
 
 TestDockerHub: {
 	// Generate some random
-	random: bl.BashScript & {
+	random: bl.#BashScript & {
 		runPolicy: "always"
 		code: """
 		echo -n $RANDOM > /rand
@@ -25,7 +25,7 @@ TestDockerHub: {
 	image: "\(TestConfig.dockerHubRepository):test-dh-\(rand)"
 
 	// Build a test image
-	build: bl.Build & {
+	build: bl.#Build & {
 		dockerfile: #"""
 			FROM alpine:latest@sha256:ab00606a42621fb68f2ed6ad3c88be54397f981a7b70a79db3d1172b11c4367d
 			RUN echo "\#(rand)" > /test
@@ -33,27 +33,27 @@ TestDockerHub: {
 	}
 
 	// Get the GCR credentials
-	login: Credentials & {
+	login: #Credentials & {
 		config: TestConfig.dockerHubConfig
 		target: image
 	}
 
 	// Push the image
-	export: bl.Push & {
-		source:      build.image
-		target:      image
-		auth:        login.auth
+	export: bl.#Push & {
+		source: build.image
+		target: image
+		auth:   login.auth
 	}
 
 	// Pull the image and verify
-	test: bl.Build & {
-		dockerfile:  #"""
+	test: bl.#Build & {
+		dockerfile: #"""
 			FROM \#(image)
 			# create a dependency between this task and export
 			RUN echo \#(export.ref)
 			RUN cat /test
 			RUN test "$(cat /test)" = "\#(rand)"
 		"""#
-		auth: login.auth
+		auth:       login.auth
 	}
 }

--- a/pkg/experimental/nodejs/nodejs.cue
+++ b/pkg/experimental/nodejs/nodejs.cue
@@ -4,10 +4,10 @@ import (
 	"blocklayer.dev/bl"
 )
 
-Container :: {
+#Container: {
 	buildScript: string
 	runScript:   string
 	environment: [string]: string
-	source: bl.Directory
-	image:  bl.Directory
+	source: bl.#Directory
+	image:  bl.#Directory
 }

--- a/pkg/file/file.cue
+++ b/pkg/file/file.cue
@@ -7,9 +7,9 @@ import (
 )
 
 // Read reads the contents of a file.
-Read :: {
+#Read: {
 	// source directory
-	source: bl.Directory
+	source: bl.#Directory
 
 	// filename names the file to read.
 	filename: !=""
@@ -17,7 +17,7 @@ Read :: {
 	// contents is the read contents.
 	contents: script.output["/output"]
 
-	script: bl.BashScript & {
+	script: bl.#BashScript & {
 		input: "/src":         source
 		output: "/output":     string
 		environment: FILENAME: filename
@@ -28,9 +28,10 @@ Read :: {
 }
 
 // Create writes contents to the given file.
-Create :: {
+
+#Create: {
 	// source directory
-	source?: bl.Directory
+	source?: bl.#Directory
 
 	// result directory
 	result: script.output["/result"]
@@ -44,12 +45,12 @@ Create :: {
 	// contents specifies the bytes to be written.
 	contents: bytes | string
 
-	script: bl.BashScript & {
-		if (source & bl.Directory) != _|_ {
+	script: bl.#BashScript & {
+		if (source & bl.#Directory) != _|_ {
 			input: "/src": source
 		}
 		input: "/contents": contents
-		output: "/result":  bl.Directory
+		output: "/result":  bl.#Directory
 		environment: {
 			FILENAME: filename
 			PERM:     strconv.FormatInt(permissions, 8)
@@ -65,9 +66,9 @@ Create :: {
 }
 
 // Append writes contents to the given file.
-Append :: {
+#Append: {
 	// source directory
-	source: bl.Directory
+	source: bl.#Directory
 
 	// result directory
 	result: script.output["/result"]
@@ -81,10 +82,10 @@ Append :: {
 	// contents specifies the bytes to be written.
 	contents: bytes | string
 
-	script: bl.BashScript & {
+	script: bl.#BashScript & {
 		input: "/src":      source
 		input: "/contents": contents
-		output: "/result":  bl.Directory
+		output: "/result":  bl.#Directory
 		environment: {
 			FILENAME: filename
 			PERM:     strconv.FormatInt(permissions, 8)
@@ -102,9 +103,9 @@ Append :: {
 }
 
 // Glob returns a list of files.
-Glob :: {
+#Glob: {
 	// source directory
-	source: bl.Directory
+	source: bl.#Directory
 
 	// glob specifies the pattern to match files with.
 	glob: !=""
@@ -113,7 +114,7 @@ Glob :: {
 	files: [...string]
 	files: json.Unmarshal(script.output["/result.json"])
 
-	script: bl.BashScript & {
+	script: bl.#BashScript & {
 		input: "/src":          source
 		output: "/result.json": string
 		environment: GLOB:      glob

--- a/pkg/file/file_test.cue
+++ b/pkg/file/file_test.cue
@@ -5,14 +5,14 @@ import (
 )
 
 TestRead: {
-	read: Read & {
-		source: bl.Directory & {
+	read: #Read & {
+		source: bl.#Directory & {
 			source: "context://testdata"
 		}
 		filename: "/file"
 	}
 
-	test: bl.BashScript & {
+	test: bl.#BashScript & {
 		input: "/test": read.contents
 		code: """
         test "$(cat /test)" = "testfile"
@@ -21,8 +21,8 @@ TestRead: {
 }
 
 TestCreate: {
-	create: Create & {
-		source: bl.Directory & {
+	create: #Create & {
+		source: bl.#Directory & {
 			source: "context://testdata"
 		}
 		filename:    "/new"
@@ -30,7 +30,7 @@ TestCreate: {
 		permissions: 0o755
 	}
 
-	test: bl.BashScript & {
+	test: bl.#BashScript & {
 		input: "/test": create.result
 		code: """
         test -x "/test/new"
@@ -40,12 +40,12 @@ TestCreate: {
 }
 
 TestCreateNoSource: {
-	create: Create & {
+	create: #Create & {
 		filename: "/new"
 		contents: "new file"
 	}
 
-	test: bl.BashScript & {
+	test: bl.#BashScript & {
 		input: "/test": create.result
 		code: """
         test "$(cat /test/new)" = "new file"
@@ -54,16 +54,16 @@ TestCreateNoSource: {
 }
 
 TestAppend: {
-	append: Append & {
-		source: bl.Directory & {
+	append: #Append & {
+		source: bl.#Directory & {
 			source: "context://testdata"
 		}
 		filename: "/file"
 		contents: "new content"
 	}
 
-	create: Append & {
-		source: bl.Directory & {
+	create: #Append & {
+		source: bl.#Directory & {
 			source: "context://testdata"
 		}
 		filename:    "/new"
@@ -71,7 +71,7 @@ TestAppend: {
 		permissions: 0o755
 	}
 
-	test: bl.BashScript & {
+	test: bl.#BashScript & {
 		input: "/append": append.result
 		input: "/create": create.result
 		code: """
@@ -84,14 +84,14 @@ TestAppend: {
 }
 
 TestGlob: {
-	glob: Glob & {
-		source: bl.Directory & {
+	glob: #Glob & {
+		source: bl.#Directory & {
 			source: "context://testdata"
 		}
 		glob: "f*"
 	}
 
-	test: bl.BashScript & {
+	test: bl.#BashScript & {
 		input: "/result.json": glob.files[0]
 		code: """
         test "$(cat /result.json)" = "file"

--- a/pkg/git/git.cue
+++ b/pkg/git/git.cue
@@ -7,19 +7,19 @@ import (
 )
 
 // Git repository
-Repository :: {
+#Repository: {
 
 	// URL of the Repository
 	url: string
 
 	// SSH key for private repositories
-	sshKey?: bl.Secret
+	sshKey?: bl.#Secret
 
 	// SSH or HTTP username to use in the git URL
 	username?: string
 
 	// HTTP password
-	httpPassword?: bl.Secret
+	httpPassword?: bl.#Secret
 
 	// Git Ref to checkout
 	ref: *"master" | string
@@ -37,7 +37,7 @@ Repository :: {
 	// Output short-commit ID of the Repository
 	shortCommit: strings.TrimRight(output["/outputs/short-commit"], "\n")
 
-	bl.BashScript & {
+	bl.#BashScript & {
 		os: package: {
 			git:     true
 			openssh: true
@@ -48,7 +48,7 @@ Repository :: {
 		input: {
 			"/inputs/url": url
 			"/inputs/ref": ref
-			if (sshKey & bl.Secret) != _|_ {
+			if (sshKey & bl.#Secret) != _|_ {
 				"/inputs/ssh-key": sshKey
 			}
 			if keepGitDir {
@@ -57,14 +57,14 @@ Repository :: {
 			if (username & string) != _|_ {
 				"/inputs/username": username
 			}
-			if (httpPassword & bl.Secret) != _|_ {
+			if (httpPassword & bl.#Secret) != _|_ {
 				"/inputs/http-password": httpPassword
 			}
-			"/cache/git": bl.Cache
+			"/cache/git": bl.#Cache
 		}
 
 		output: {
-			"/outputs/out":          bl.Directory
+			"/outputs/out":          bl.#Directory
 			"/outputs/commit":       string
 			"/outputs/short-commit": string
 		}
@@ -121,10 +121,10 @@ Repository :: {
 }
 
 // Retrieve commit IDs from a git working copy (ie. cloned repository)
-PathCommit :: {
+#PathCommit: {
 
 	// Source Directory (git working copy)
-	from: bl.Directory
+	from: bl.#Directory
 
 	// Optional path to retrieve git commit IDs from
 	path: *"./" | string
@@ -135,7 +135,7 @@ PathCommit :: {
 	// Output short-commit ID of the Repository
 	shortCommit: strings.TrimRight(pathCommit.output["/outputs/short-commit"], "\n")
 
-	pathCommit: bl.BashScript & {
+	pathCommit: bl.#BashScript & {
 		os: package: git: true
 
 		workdir: "/workdir"

--- a/pkg/git/git_test.cue
+++ b/pkg/git/git_test.cue
@@ -3,12 +3,12 @@ package git
 import "blocklayer.dev/bl"
 
 testClone: {
-	run: Repository & {
+	run: #Repository & {
 		url: "https://github.com/blocklayerhq/actions"
 		ref: "2dd1ba045e7dc4e382ae89529b0e9e2107a076bb"
 	}
 
-	test: bl.BashScript & {
+	test: bl.#BashScript & {
 		input: {
 			"/inputs/out":          run.out
 			"/inputs/commit":       run.commit
@@ -25,13 +25,13 @@ testClone: {
 }
 
 testCloneWithGitDir: {
-	run: Repository & {
+	run: #Repository & {
 		url:        "https://github.com/blocklayerhq/actions"
 		ref:        "2dd1ba045e7dc4e382ae89529b0e9e2107a076bb"
 		keepGitDir: true
 	}
 
-	test: bl.BashScript & {
+	test: bl.#BashScript & {
 		input: "/inputs/out": run.out
 
 		code: #"""
@@ -41,17 +41,17 @@ testCloneWithGitDir: {
 }
 
 testPathCommit: {
-	repos: Repository & {
+	repos: #Repository & {
 		url:        "https://github.com/blocklayerhq/actions"
 		ref:        "2dd1ba045e7dc4e382ae89529b0e9e2107a076bb"
 		keepGitDir: true
 	}
 
-	run: PathCommit & {
+	run: #PathCommit & {
 		from: repos.out
 	}
 
-	test: bl.BashScript & {
+	test: bl.#BashScript & {
 		input: {
 			"/inputs/commit":       run.commit
 			"/inputs/short-commit": run.shortCommit

--- a/pkg/github/comment.cue
+++ b/pkg/github/comment.cue
@@ -6,27 +6,26 @@ import (
 	"strings"
 )
 
-CommentFields :: {
+#CommentFields: {
 	id:   string
 	body: string
 }
-
-CommentFragment :: """
+#CommentFragment: """
     fragment CommentParts on IssueComment {
         id
         body
     }
     """
 
-AddComment :: {
+#AddComment: {
 	subjectId: string
 	body:      string
 
 	data:    _
-	comment: CommentFields
+	comment: #CommentFields
 	comment: data.addComment.commentEdge.node
 
-	Query & {
+	#Query & {
 		query: """
         mutation ($input: AddCommentInput!) {
             addComment(input: $input) {
@@ -40,7 +39,7 @@ AddComment :: {
                 }
             }
         }
-        \(CommentFragment)
+        \(#CommentFragment)
         """
 
 		variable: input: {
@@ -50,15 +49,15 @@ AddComment :: {
 	}
 }
 
-UpdateComment :: {
+#UpdateComment: {
 	commentId: string
 	body:      string
 
 	data:    _
-	comment: CommentFields
+	comment: #CommentFields
 	comment: data.updateIssueComment.issueComment
 
-	Query & {
+	#Query & {
 		query: """
         mutation ($input: UpdateIssueCommentInput!) {
             updateIssueComment(input: $input) {
@@ -67,7 +66,7 @@ UpdateComment :: {
                 }
             }
         }
-        \(CommentFragment)
+        \(#CommentFragment)
         """
 
 		variable: input: {
@@ -77,13 +76,13 @@ UpdateComment :: {
 	}
 }
 
-Comment :: {
+#Comment: {
 	subjectId: string
 	marker:    *"<!-- bl-marker-do-not-remove -->" | string
-	token:     bl.Secret
+	token:     bl.#Secret
 	body:      string
 
-	listComments: Query & {
+	listComments: #Query & {
 		"token": token
 
 		query:
@@ -101,7 +100,7 @@ Comment :: {
                     }
                 }
             }
-            \(CommentFragment)
+            \(#CommentFragment)
             """
 		variable: {
 			nodeId: subjectId
@@ -109,10 +108,10 @@ Comment :: {
 	}
 
 	// Contains a list of comment ID matching the marker
-	commentId: [n.id for n in listComments.data.node.comments.nodes if strings.Contains(n.body, "\(marker)")]
+	commentId: [ for n in listComments.data.node.comments.nodes if strings.Contains(n.body, "\(marker)") {n.id}]
 
 	updateCommentQuery: json.Marshal({
-		query: UpdateComment.query
+		query: #UpdateComment.query
 		variables: input: {
 			if len(commentId) > 0 {
 				id: commentId[0]
@@ -122,14 +121,14 @@ Comment :: {
 	})
 
 	addCommentQuery: json.Marshal({
-		query: AddComment.query
+		query: #AddComment.query
 		variables: input: {
 			"subjectId": subjectId
 			"body":      "\(body)\n\(marker)"
 		}
 	})
 
-	editComment: bl.BashScript & {
+	editComment: bl.#BashScript & {
 		os: package: curl: true
 		input: {
 			"/token": token

--- a/pkg/github/comment_test.cue
+++ b/pkg/github/comment_test.cue
@@ -1,61 +1,61 @@
 package github
 
 import (
-    "blocklayer.dev/bl"
-    "encoding/json"
+	"blocklayer.dev/bl"
+	"encoding/json"
 )
 
-TestConfig: githubToken: bl.Secret
+TestConfig: githubToken: bl.#Secret
 
 TestComment: {
-    query: GetPullRequest & {
-        token:  TestConfig.githubToken
-        number: 2
-        repo: {
-            owner: "stackbrew-test"
-            name:  "gh-test"
-        }
-    }
+	query: #GetPullRequest & {
+		token:  TestConfig.githubToken
+		number: 2
+		repo: {
+			owner: "stackbrew-test"
+			name:  "gh-test"
+		}
+	}
 
-    addComment: AddComment & {
-        token:     TestConfig.githubToken
-        subjectId: query.pullRequest.id
-        body:      #"""
+	addComment: #AddComment & {
+		token:     TestConfig.githubToken
+		subjectId: query.pullRequest.id
+		body:      #"""
         ## Stackbrew Test
 
         ```
         \#(json.Indent(
-            json.Marshal(query.pullRequest),
-            "", "  "
-        ))
+				json.Marshal(query.pullRequest),
+				"", "  ",
+				))
         ```
         """#
-    }
+	}
 
-    updateComment: UpdateComment & {
-        token:     TestConfig.githubToken
-        commentId: addComment.comment.id
-        body:      #"""
+	updateComment: #UpdateComment & {
+		token:     TestConfig.githubToken
+		commentId: addComment.comment.id
+		body:      #"""
         \#(addComment.body)
 
         **UPDATED**
         """#
-    }
+	}
 
-    commentWithMarker: Comment & {
-        token: TestConfig.githubToken
-        subjectId: query.pullRequest.id
-        body:      #"""
+	commentWithMarker: #Comment & {
+		token:     TestConfig.githubToken
+		subjectId: query.pullRequest.id
+		body:      #"""
         ## Stackbrew Test
 
         Edit comment in place
 
         ```
         \#(json.Indent(
-            json.Marshal(query.pullRequest),
-            "", "  "
-        ))
+				json.Marshal(query.pullRequest),
+				"", "  ",
+				))
         ```
         """#
-    }
+	}
 }

--- a/pkg/github/event.cue
+++ b/pkg/github/event.cue
@@ -2,7 +2,7 @@ package github
 
 // GitHub Event
 // https://developer.github.com/v3/activity/events
-Event :: {
+#Event: {
 	name: string
 
 	sender: {...}
@@ -12,13 +12,13 @@ Event :: {
 	// FIXME: handle other events
 	{
 		name: "pull_request"
-		PullRequestEvent
+		#PullRequestEvent
 	}
 }
 
 // PullRequestEvent
 // https://developer.github.com/v3/activity/events/types/#pullrequestevent
-PullRequestEvent :: {
+#PullRequestEvent: {
 	action:
 		"assigned" |
 		"unassigned" |

--- a/pkg/github/pull_request.cue
+++ b/pkg/github/pull_request.cue
@@ -5,7 +5,7 @@ import (
 	"blocklayer.dev/git"
 )
 
-PullRequest :: {
+#PullRequest: {
 	id:     string
 	state:  string
 	number: int
@@ -22,7 +22,7 @@ PullRequest :: {
 }
 
 // INTERNAL: GraphQL fragment shared across queries related to PullRequest
-PullRequestParts :: """
+#PullRequestParts: """
     fragment PullRequestParts on PullRequest {
         id
         state
@@ -41,8 +41,7 @@ PullRequestParts :: """
         }
     }
     """
-
-GetPullRequest :: {
+#GetPullRequest: {
 	number: int
 
 	repo: {
@@ -50,7 +49,7 @@ GetPullRequest :: {
 		name:  string
 	}
 
-	Query & {
+	#Query & {
 		query:
 			"""
             query($owner: String!, $name: String!, $number: Int!) {
@@ -60,7 +59,7 @@ GetPullRequest :: {
                     }
                 }
             }
-            \(PullRequestParts)
+            \(#PullRequestParts)
             """
 		variable: {
 			owner:    repo.owner
@@ -70,26 +69,25 @@ GetPullRequest :: {
 	}
 
 	data:        _
-	pullRequest: PullRequest
+	pullRequest: #PullRequest
 	pullRequest: data.repository.pullRequest
 }
 
 // FIXME: this should be PullRequest::Checkout
-CheckoutPullRequest :: {
-	pullRequest: PullRequest
+#CheckoutPullRequest: {
+	pullRequest: #PullRequest
 
 	// Github API token
-	token: bl.Secret
+	token: bl.#Secret
 
-	git.Repository & {
+	git.#Repository & {
 		url:          pullRequest.headRepository.url
 		ref:          pullRequest.headRef.target.oid
 		username:     "apikey"
 		httpPassword: token
 	}
 }
-
-ListPullRequests :: {
+#ListPullRequests: {
 	repo: {
 		owner: string
 		name:  string
@@ -97,7 +95,7 @@ ListPullRequests :: {
 	pageSize: int | *25
 	states:   [string] | *[]
 
-	Query & {
+	#Query & {
 		query:
 			"""
             query($owner: String!, $name: String!, $last: Int, $states: [PullRequestState!]) {
@@ -109,7 +107,7 @@ ListPullRequests :: {
                     }
                 }
             }
-            \(PullRequestParts)
+            \(#PullRequestParts)
             """
 		variable: {
 			owner:    repo.owner
@@ -120,6 +118,6 @@ ListPullRequests :: {
 	}
 
 	data: _
-	pullRequests: [...PullRequest]
+	pullRequests: [...#PullRequest]
 	pullRequests: data.repository.pullRequests.nodes
 }

--- a/pkg/github/pull_request_test.cue
+++ b/pkg/github/pull_request_test.cue
@@ -1,103 +1,103 @@
 package github
 
 import (
-    "blocklayer.dev/bl"
+	"blocklayer.dev/bl"
 )
 
-TestConfig: githubToken: bl.Secret
+TestConfig: githubToken: bl.#Secret
 
 TestGetPullRequestMerged: {
-    query: GetPullRequest & {
-        token:  TestConfig.githubToken
-        number: 1
-        repo: {
-            owner: "stackbrew-test"
-            name:  "gh-test"
-        }
-    }
+	query: #GetPullRequest & {
+		token:  TestConfig.githubToken
+		number: 1
+		repo: {
+			owner: "stackbrew-test"
+			name:  "gh-test"
+		}
+	}
 
-    test: bl.BashScript & {
-        runPolicy: "always"
-        environment: state: query.pullRequest.state
-        code: """
+	test: bl.#BashScript & {
+		runPolicy: "always"
+		environment: state: query.pullRequest.state
+		code: """
         test "$state" = "MERGED"
         """
-    }
+	}
 }
 
 TestGetPullRequestOpen: {
-    query: GetPullRequest & {
-        token:  TestConfig.githubToken
-        number: 2
-        repo: {
-            owner: "stackbrew-test"
-            name:  "gh-test"
-        }
-    }
+	query: #GetPullRequest & {
+		token:  TestConfig.githubToken
+		number: 2
+		repo: {
+			owner: "stackbrew-test"
+			name:  "gh-test"
+		}
+	}
 
-    test: bl.BashScript & {
-        runPolicy: "always"
-        environment: {
-            state:  query.pullRequest.state
-            gitUrl: query.pullRequest.headRepository.url
-            commit: query.pullRequest.headRef.target.oid
-        }
-        code: """
+	test: bl.#BashScript & {
+		runPolicy: "always"
+		environment: {
+			state:  query.pullRequest.state
+			gitUrl: query.pullRequest.headRepository.url
+			commit: query.pullRequest.headRef.target.oid
+		}
+		code: """
         test "$state" = "OPEN"
         test "$gitUrl" = "https://github.com/stackbrew-test/gh-test"
         test "$commit" = "16a9a0fffda42bfbab40cfba79ecef61c7343e65"
         """
-    }
+	}
 }
 
 TestCheckoutPullRequest: {
-    query: GetPullRequest & {
-        token:  TestConfig.githubToken
-        number: 2
-        repo: {
-            owner: "stackbrew-test"
-            name:  "gh-test"
-        }
-    }
+	query: #GetPullRequest & {
+		token:  TestConfig.githubToken
+		number: 2
+		repo: {
+			owner: "stackbrew-test"
+			name:  "gh-test"
+		}
+	}
 
-    checkout: CheckoutPullRequest & {
-        token: TestConfig.githubToken
-        pullRequest: query.pullRequest
-    }
+	checkout: #CheckoutPullRequest & {
+		token:       TestConfig.githubToken
+		pullRequest: query.pullRequest
+	}
 
-    test: bl.BashScript & {
-        runPolicy: "always"
-        input: "/checkout": checkout.out
-        code: """
+	test: bl.#BashScript & {
+		runPolicy: "always"
+		input: "/checkout": checkout.out
+		code: """
         grep -q "FROM PR2" /checkout/README.md
         """
-    }
+	}
 }
 
 TestListPullRequests: {
-    query: ListPullRequests & {
-        token:    TestConfig.githubToken
-        pageSize: 10
-        states:   ["MERGED"]
-        repo: {
-            owner: "stackbrew-test"
-            name:  "gh-test"
-        }
-    }
+	query: #ListPullRequests & {
+		token:    TestConfig.githubToken
+		pageSize: 10
+		states: ["MERGED"]
+		repo: {
+			owner: "stackbrew-test"
+			name:  "gh-test"
+		}
+	}
 
-    test: bl.BashScript & {
-        runPolicy: "always"
-        environment: {
-            FIRST_PR_STATE: "\(query.pullRequests[0].state)"
-            for pr in query.pullRequests {
-                "PR_\(pr.number)_STATE": pr.state
-            }
-        }
-        code: """
+	test: bl.#BashScript & {
+		runPolicy: "always"
+		environment: {
+			FIRST_PR_STATE: "\(query.pullRequests[0].state)"
+			for pr in query.pullRequests {
+				"PR_\(pr.number)_STATE": pr.state
+			}
+		}
+		code: """
         env
         test "$FIRST_PR_STATE" = "MERGED"
         test "$PR_1_STATE" = "MERGED"
         test -z "$PR_2_STATE"
         """
-    }
+	}
 }

--- a/pkg/github/query.cue
+++ b/pkg/github/query.cue
@@ -9,10 +9,10 @@ import (
 )
 
 // GitHub v4 GraphQL Query
-Query :: {
-	token: bl.Secret
+#Query: {
+	token: bl.#Secret
 
-	graphql.Query & {
+	graphql.#Query & {
 		url: "https://api.github.com/graphql"
 
 		request: {

--- a/pkg/github/repository.cue
+++ b/pkg/github/repository.cue
@@ -4,7 +4,7 @@ import (
 	"blocklayer.dev/bl"
 )
 
-Repository :: {
+#Repository: {
 	// Github repository name
 	name: string
 
@@ -12,9 +12,8 @@ Repository :: {
 	owner: string
 
 	// Github API token
-	token: bl.Secret
-
-	"GetPullRequest" :: GetPullRequest & {
+	token:           bl.#Secret
+	#GetPullRequest: #GetPullRequest & {
 		"token": token
 		repo: {
 			"owner": owner

--- a/pkg/github/repository.cue
+++ b/pkg/github/repository.cue
@@ -4,6 +4,10 @@ import (
 	"blocklayer.dev/bl"
 )
 
+
+// FIXME: weird behavior, talk to Marcel
+let tlGetPullRequest=#GetPullRequest
+
 #Repository: {
 	// Github repository name
 	name: string
@@ -13,7 +17,7 @@ import (
 
 	// Github API token
 	token:           bl.#Secret
-	#GetPullRequest: #GetPullRequest & {
+	#GetPullRequest: tlGetPullRequest & {
 		"token": token
 		repo: {
 			"owner": owner

--- a/pkg/github/repository_test.cue
+++ b/pkg/github/repository_test.cue
@@ -1,32 +1,32 @@
 package github
 
 import (
-    "blocklayer.dev/bl"
+	"blocklayer.dev/bl"
 )
 
-TestConfig: githubToken: bl.Secret
+TestConfig: githubToken: bl.#Secret
 
 TestRepository: {
-    repository: Repository & {
-        name:  "gh-test"
-        owner: "stackbrew-test"
-        token: TestConfig.githubToken
-    }
+	repository: #Repository & {
+		name:  "gh-test"
+		owner: "stackbrew-test"
+		token: TestConfig.githubToken
+	}
 
-    pr: repository.GetPullRequest & {
-        number: 2
-    }
+	pr: repository.#GetPullRequest & {
+		number: 2
+	}
 
-    checkout: CheckoutPullRequest & {
-        pullRequest: pr.pullRequest
-        token: TestConfig.githubToken
-    }
+	checkout: #CheckoutPullRequest & {
+		pullRequest: pr.pullRequest
+		token:       TestConfig.githubToken
+	}
 
-    test: bl.BashScript & {
-        runPolicy: "always"
-        input: "/checkout": checkout.out
-        code: """
+	test: bl.#BashScript & {
+		runPolicy: "always"
+		input: "/checkout": checkout.out
+		code: """
         grep -q "FROM PR2" /checkout/README.md
         """
-    }
+	}
 }

--- a/pkg/github/user.cue
+++ b/pkg/github/user.cue
@@ -5,28 +5,25 @@ package github
 //
 // This package matches the raw Github types and queries as closely as possible.
 // For a higher-level package, see the top-level `github` package.
-
-User :: {
+#User: {
 	id:    string
 	login: string
 }
-
-UserFragment :: """
+#UserFragment: """
     fragment UserParts on User {
         id
         login
     }
     """
-
-GetViewer :: {
-	Query & {
+#GetViewer: {
+	#Query & {
 		query: """
         query {
             viewer {
                 ...UserParts
             }
         }
-        \(UserFragment)
+        \(#UserFragment)
         """
 	}
 

--- a/pkg/github/user_test.cue
+++ b/pkg/github/user_test.cue
@@ -1,21 +1,21 @@
 package github
 
 import (
-    "blocklayer.dev/bl"
+	"blocklayer.dev/bl"
 )
 
-TestConfig: githubToken: bl.Secret
+TestConfig: githubToken: bl.#Secret
 
 TestViewer: {
-    query: GetViewer & {
-        token: TestConfig.githubToken
-    }
+	query: #GetViewer & {
+		token: TestConfig.githubToken
+	}
 
-    test: bl.BashScript & {
-        runPolicy: "always"
-        environment: login: query.user.login
-        code: """
+	test: bl.#BashScript & {
+		runPolicy: "always"
+		environment: login: query.user.login
+		code: """
         test "$login" = "stackbrew-test"
         """
-    }
+	}
 }

--- a/pkg/go/go.cue
+++ b/pkg/go/go.cue
@@ -3,10 +3,10 @@ package go
 import "blocklayer.dev/bl"
 
 // Go application built with `go build`
-App :: {
+#App: {
 
 	// Source Directory to build
-	source: bl.Directory
+	source: bl.#Directory
 
 	// Go version to use
 	version: *"1.14.1" | string
@@ -30,12 +30,12 @@ App :: {
 	binaryName: string
 
 	// Binary file output of the Go build
-	binary: bl.Directory & {
+	binary: bl.#Directory & {
 		source: build.output["/outputs/out"]
 		path:   binaryName
 	}
 
-	build: bl.BashScript & {
+	build: bl.#BashScript & {
 		input: {
 			"/inputs/source":  source
 			"/inputs/version": version
@@ -47,10 +47,10 @@ App :: {
 			"/inputs/os":         osInput
 			"/inputs/tags":       tags
 			"/inputs/ldflags":    ldflags
-			"/cache/go":          bl.Cache
+			"/cache/go":          bl.#Cache
 		}
 
-		output: "/outputs/out": bl.Directory
+		output: "/outputs/out": bl.#Directory
 
 		os: package: {
 			"libc6-compat": true

--- a/pkg/go/go_test.cue
+++ b/pkg/go/go_test.cue
@@ -3,14 +3,14 @@ package go
 import "blocklayer.dev/bl"
 
 testGoBuild: {
-	run: App & {
-		source: bl.Directory & {
+	run: #App & {
+		source: bl.#Directory & {
 			source: "context://testdata"
 		}
 		binaryName: "app"
 	}
 
-	test: bl.BashScript & {
+	test: bl.#BashScript & {
 		input: "/inputs/binary": run.binary
 		code: #"""
             [ "$(/inputs/binary)" = "hello world" ]

--- a/pkg/googlecloud/gcr/gcr.cue
+++ b/pkg/googlecloud/gcr/gcr.cue
@@ -7,32 +7,32 @@ import (
 )
 
 // Credentials retriever for GCR
-Credentials :: {
+#Credentials: {
 
 	// GCP Config
-	config: googlecloud.Config
+	config: googlecloud.#Config
 
 	// Target is the GCR image
 	target: string
 
 	// Registry Credentials
-	credentials: bl.RegistryCredentials & {
+	credentials: bl.#RegistryCredentials & {
 		username: output["/outputs/username"]
-		secret:   bl.Secret & {
+		secret:   bl.#Secret & {
 			// FIXME: we should be able to output a bl.Secret directly
 			value: base64.Encode(null, output["/outputs/secret"])
 		}
 	}
 
 	// Authentication for GCR Registries
-	auth: bl.RegistryAuth
+	auth: bl.#RegistryAuth
 	auth: "\(target)": credentials
 
 	helperUrl:
 		"https://github.com/GoogleCloudPlatform/docker-credential-gcr/releases/download/v2.0.1/docker-credential-gcr_linux_amd64-2.0.1.tar.gz"
 
 	output: _
-	bl.BashScript & {
+	bl.#BashScript & {
 		runPolicy: "always"
 
 		input: {

--- a/pkg/googlecloud/gcr/gcr_test.cue
+++ b/pkg/googlecloud/gcr/gcr_test.cue
@@ -5,14 +5,14 @@ import (
 	"blocklayer.dev/googlecloud"
 )
 
-TestConfig : {
-	gcpConfig:     googlecloud.Config
+TestConfig: {
+	gcpConfig:     googlecloud.#Config
 	gcrRepository: string
 }
 
 TestGCR: {
 	// Generate some random
-	random: bl.BashScript & {
+	random: bl.#BashScript & {
 		runPolicy: "always"
 		code: """
 		echo -n $RANDOM > /rand
@@ -26,7 +26,7 @@ TestGCR: {
 	image: "\(TestConfig.gcrRepository):test-gcr-\(rand)"
 
 	// Build a test image
-	build: bl.Build & {
+	build: bl.#Build & {
 		dockerfile: #"""
 			FROM alpine:latest@sha256:ab00606a42621fb68f2ed6ad3c88be54397f981a7b70a79db3d1172b11c4367d
 			RUN echo "\#(rand)" > /test
@@ -34,27 +34,27 @@ TestGCR: {
 	}
 
 	// Get the GCR credentials
-	login: Credentials & {
+	login: #Credentials & {
 		config: TestConfig.gcpConfig
 		target: image
 	}
 
 	// Push the image
-	export: bl.Push & {
-		source:      build.image
-		target:      login.target
-		auth:        login.auth
+	export: bl.#Push & {
+		source: build.image
+		target: login.target
+		auth:   login.auth
 	}
 
 	// Pull the image and verify
-	test: bl.Build & {
-		dockerfile:  #"""
+	test: bl.#Build & {
+		dockerfile: #"""
 			FROM \#(image)
 			# create a dependency between this task and export
 			RUN echo \#(export.ref)
 			RUN cat /test
 			RUN test "$(cat /test)" = "\#(rand)"
 		"""#
-		auth: login.auth
+		auth:       login.auth
 	}
 }

--- a/pkg/googlecloud/gke/gke.cue
+++ b/pkg/googlecloud/gke/gke.cue
@@ -7,25 +7,26 @@ import (
 )
 
 // KubeConfig config outputs a valid kube-auth-config for kubectl client
-KubeConfig :: {
+
+#KubeConfig: {
 	// GCP Config
-	config: googlecloud.Config
+	config: googlecloud.#Config
 
 	// GKE cluster name
 	cluster: string
 
 	// kubeconfig is the generated kube configuration file
-	kubeconfig: bl.Secret & {
+	kubeconfig: bl.#Secret & {
 		// FIXME: we should be able to output a bl.Secret directly
 		value: base64.Encode(null, run.output["/outputs/kubeconfig"])
 	}
 
-	run: bl.BashScript & {
+	run: bl.#BashScript & {
 		runPolicy: "always"
 
 		input: {
 			"/inputs/service_key": config.serviceKey
-			"/cache/googlecloud":  bl.Cache
+			"/cache/googlecloud":  bl.#Cache
 		}
 
 		output: "/outputs/kubeconfig": string

--- a/pkg/googlecloud/gke/gke_test.cue
+++ b/pkg/googlecloud/gke/gke_test.cue
@@ -7,13 +7,13 @@ import (
 )
 
 TestConfig: {
-	gcpConfig:     googlecloud.Config
-    gkeClusterName: string
+	gcpConfig:      googlecloud.#Config
+	gkeClusterName: string
 }
 
 TestGKE: {
 	// Generate some random
-	genRandom: bl.BashScript & {
+	genRandom: bl.#BashScript & {
 		runPolicy: "always"
 		code: """
 		echo -n $RANDOM > /rand
@@ -23,17 +23,17 @@ TestGKE: {
 
 	random: genRandom.output["/rand"]
 
-    // Authenticate against GKE
-    authenticate: KubeConfig & {
-        config: TestConfig.gcpConfig
-        cluster: TestConfig.gkeClusterName
-    }
+	// Authenticate against GKE
+	authenticate: #KubeConfig & {
+		config:  TestConfig.gcpConfig
+		cluster: TestConfig.gkeClusterName
+	}
 
-    // Deploy a dummy config
-    deploy: kubernetes.Apply & {
-        kubeconfig: authenticate.kubeconfig
-        namespace: "stackbrew-test"
-        source: #"""
+	// Deploy a dummy config
+	deploy: kubernetes.#Apply & {
+		kubeconfig: authenticate.kubeconfig
+		namespace:  "stackbrew-test"
+		source:     #"""
             apiVersion: v1
             kind: Pod
             metadata:
@@ -44,5 +44,5 @@ TestGKE: {
                     - name: test
                       image: hello-world
             """#
-    }
+	}
 }

--- a/pkg/googlecloud/googlecloud.cue
+++ b/pkg/googlecloud/googlecloud.cue
@@ -1,10 +1,12 @@
 package googlecloud
 
-import "blocklayer.dev/bl"
+import ( "blocklayer.dev/bl"
 
-// Google Cloud Config shared by all packages
-Config :: {
+	// Google Cloud Config shared by all packages
+)
+
+#Config: {
 	region:     string
 	project:    string
-	serviceKey: bl.Secret
+	serviceKey: bl.#Secret
 }

--- a/pkg/graphql/graphql.cue
+++ b/pkg/graphql/graphql.cue
@@ -5,7 +5,7 @@ import (
 	"blocklayer.dev/http"
 )
 
-Query :: {
+#Query: {
 	// Contents of the graphql query
 	query: string
 	// graphql variables

--- a/pkg/http/http.cue
+++ b/pkg/http/http.cue
@@ -6,19 +6,18 @@ import (
 	"strconv"
 )
 
-Get:    Do & {method: "GET"}
-Post:   Do & {method: "POST"}
-Put:    Do & {method: "PUT"}
-Delete: Do & {method: "DELETE"}
-
-Do :: {
+Get:    #Do & {method: "GET"}
+Post:   #Do & {method: "POST"}
+Put:    #Do & {method: "PUT"}
+Delete: #Do & {method: "DELETE"}
+#Do: {
 	url:    string
 	method: "GET" | "POST" | "PUT" | "DELETE" | "PATH" | "HEAD"
 
 	request: {
 		body: string | *""
 		header: [string]: string | [...string]
-		token?: bl.Secret
+		token?: bl.#Secret
 	}
 
 	output: [string]: string
@@ -27,13 +26,13 @@ Do :: {
 		statusCode: strconv.Atoi(output["/status"])
 	}
 
-	bl.BashScript & {
+	bl.#BashScript & {
 		runPolicy: "always"
 		os: package: curl: true
 		input: {
 			"/method":  method
 			"/headers": json.Marshal(request.header)
-			if (request.token & bl.Secret) != _|_ {
+			if (request.token & bl.#Secret) != _|_ {
 				"/token": request.token
 			}
 			"/body": request.body

--- a/pkg/http/http_test.cue
+++ b/pkg/http/http_test.cue
@@ -1,34 +1,34 @@
 package http
 
 import (
-    "blocklayer.dev/bl"
-    "encoding/json"
+	"blocklayer.dev/bl"
+	"encoding/json"
 )
 
 TestRequest: {
-    req: Get & {
-        url: "https://api.github.com/"
-        request: header: {
-            "Accept": "application/json"
-            "Test": ["A", "B"]
-        }
-    }
+	req: Get & {
+		url: "https://api.github.com/"
+		request: header: {
+			"Accept": "application/json"
+			"Test": ["A", "B"]
+		}
+	}
 
-    testRaw: bl.BashScript & {
-        environment: STATUS: "\(req.response.statusCode)"
-        input: "/content.json": req.response.body
-        code: """
+	testRaw: bl.#BashScript & {
+		environment: STATUS:    "\(req.response.statusCode)"
+		input: "/content.json": req.response.body
+		code: """
             test "$STATUS" = 200
             test "$(cat /content.json | jq -r .current_user_url)" = "https://api.github.com/user"
             """
-    }
+	}
 
-    testJSON: bl.BashScript & {
-        environment: STATUS: "\(req.response.statusCode)"
-        environment: CONTENT: json.Unmarshal(req.response.body).current_user_url
-        code: """
+	testJSON: bl.#BashScript & {
+		environment: STATUS:  "\(req.response.statusCode)"
+		environment: CONTENT: json.Unmarshal(req.response.body).current_user_url
+		code: """
             test "$STATUS" = 200
             test "$CONTENT" = "https://api.github.com/user"
             """
-    }
+	}
 }

--- a/pkg/kubernetes/helm/helm.cue
+++ b/pkg/kubernetes/helm/helm.cue
@@ -7,12 +7,12 @@ import (
 )
 
 // Install a Helm chart
-Chart :: {
+#Chart: {
 	// Helm deployment name
 	name: string
 
 	// Helm chart to install
-	chart: string | bl.Directory
+	chart: string | bl.#Directory
 
 	// Helm chart repository (defaults to stable)
 	repository: *"https://kubernetes-charts.storage.googleapis.com/" | string
@@ -40,12 +40,12 @@ Chart :: {
 	atomic: *true | bool
 
 	// Kube config file
-	kubeconfig: bl.Secret
+	kubeconfig: bl.#Secret
 
 	// Helm version
 	version: string | *"3.1.2"
 
-	run: bl.BashScript & {
+	run: bl.#BashScript & {
 		runPolicy: "always"
 
 		os: {

--- a/pkg/kubernetes/helm/helm_test.cue
+++ b/pkg/kubernetes/helm/helm_test.cue
@@ -1,58 +1,57 @@
 package helm
 
 import (
-    "encoding/yaml"
+	"encoding/yaml"
 
-    "blocklayer.dev/bl"
+	"blocklayer.dev/bl"
 	"blocklayer.dev/aws"
 	"blocklayer.dev/aws/eks"
 )
 
 TestConfig: {
-	awsConfig:     aws.Config
-    eksClusterName: string
+	awsConfig:      aws.#Config
+	eksClusterName: string
 }
 
-
 TestHelmRepoChart: {
-    authenticate: eks.KubeConfig & {
-        config: TestConfig.awsConfig
-        cluster: TestConfig.eksClusterName
-    }
+	authenticate: eks.#KubeConfig & {
+		config:  TestConfig.awsConfig
+		cluster: TestConfig.eksClusterName
+	}
 
-    install: Chart & {
-        name: "stackbrew-test-helm-repository"
-        chart: "redis"
-        values: yaml.Marshal({
-            cluster: enabled: false
-        })
+	install: #Chart & {
+		name:   "stackbrew-test-helm-repository"
+		chart:  "redis"
+		values: yaml.Marshal({
+			cluster: enabled: false
+		})
 
-        namespace: "stackbrew-test"
-        kubeconfig: authenticate.kubeconfig
+		namespace:  "stackbrew-test"
+		kubeconfig: authenticate.kubeconfig
 
-        // Used to speed up tests
-        atomic: false
-        wait: false
-    }
+		// Used to speed up tests
+		atomic: false
+		wait:   false
+	}
 }
 
 TestHelmCustomChart: {
-    authenticate: eks.KubeConfig & {
-        config: TestConfig.awsConfig
-        cluster: TestConfig.eksClusterName
-    }
+	authenticate: eks.#KubeConfig & {
+		config:  TestConfig.awsConfig
+		cluster: TestConfig.eksClusterName
+	}
 
-    install: Chart & {
-        name: "stackbrew-test-helm-local"
-        chart: bl.Directory & {
-            source: "context://testdata/mychart"
-        }
+	install: #Chart & {
+		name:  "stackbrew-test-helm-local"
+		chart: bl.#Directory & {
+			source: "context://testdata/mychart"
+		}
 
-        namespace: "stackbrew-test"
-        kubeconfig: authenticate.kubeconfig
+		namespace:  "stackbrew-test"
+		kubeconfig: authenticate.kubeconfig
 
-        // Used to speed up tests
-        atomic: false
-        wait: false
-    }
+		// Used to speed up tests
+		atomic: false
+		wait:   false
+	}
 }

--- a/pkg/kubernetes/krane/krane.cue
+++ b/pkg/kubernetes/krane/krane.cue
@@ -5,9 +5,9 @@ import (
 )
 
 // Render a Krane template
-Render :: {
+#Render: {
 	// Kubernetes config to render
-	source: string | bl.Directory
+	source: string | bl.#Directory
 
 	// Krane version
 	version: string | *"1.1.2"
@@ -15,7 +15,7 @@ Render :: {
 	// Rendered config
 	result: run.output["/krane/result"]
 
-	run: bl.BashScript & {
+	run: bl.#BashScript & {
 		runPolicy: "always"
 
 		os: {
@@ -46,15 +46,15 @@ Render :: {
 }
 
 // Deploy a Kubernetes configuration using Krane
-Deploy :: {
+#Deploy: {
 	// Kubernetes config to deploy
-	source: string | bl.Directory
+	source: string | bl.#Directory
 
 	// Kubernetes Namespace to deploy to
 	namespace: string
 
 	// Kube config file
-	kubeconfig: bl.Secret
+	kubeconfig: bl.#Secret
 
 	// Krane version
 	version: string | *"1.1.2"
@@ -62,7 +62,7 @@ Deploy :: {
 	// Prune resources that are no longer in your Kubernetes template set
 	prune: bool | *true
 
-	deploy: bl.BashScript & {
+	deploy: bl.#BashScript & {
 		runPolicy: "always"
 
 		os: {

--- a/pkg/kubernetes/krane/krane_test.cue
+++ b/pkg/kubernetes/krane/krane_test.cue
@@ -8,13 +8,12 @@ import (
 )
 
 TestConfig: {
-	awsConfig:     aws.Config
-    eksClusterName: string
+	awsConfig:      aws.#Config
+	eksClusterName: string
 }
 
-
 TestRender: {
-    kubeCfgString : #"""
+	kubeCfgString: #"""
         apiVersion: v1
         kind: Pod
         metadata:
@@ -26,18 +25,18 @@ TestRender: {
                   image: hello-world
         """#
 
-    kubeCfgDirectory: file.Create & {
-        filename: "/test.yaml.erb"
-        contents: kubeCfgString
-    }
+	kubeCfgDirectory: file.#Create & {
+		filename: "/test.yaml.erb"
+		contents: kubeCfgString
+	}
 
-    renderString: Render & {
-        source: kubeCfgString
-    }
+	renderString: #Render & {
+		source: kubeCfgString
+	}
 
-    testString: bl.BashScript & {
-        input: "/config": renderString.result
-        code: #"""
+	testString: bl.#BashScript & {
+		input: "/config": renderString.result
+		code: #"""
         grep -q kubernetes-test- /config
 
         # Make sure the template was rendered
@@ -46,16 +45,16 @@ TestRender: {
         # Make sure that deployment_id is not empty
         test -z "$(grep "test--end" /config)"
         """#
-    }
+	}
 
-    // Render a simple config
-    renderDirectory: Render & {
-        source: kubeCfgDirectory.contents
-    }
+	// Render a simple config
+	renderDirectory: #Render & {
+		source: kubeCfgDirectory.contents
+	}
 
-    testDirectory: bl.BashScript & {
-        input: "/config": renderString.result
-        code: #"""
+	testDirectory: bl.#BashScript & {
+		input: "/config": renderString.result
+		code: #"""
         grep -q kubernetes-test- /config
 
         # Make sure the template was rendered
@@ -64,12 +63,12 @@ TestRender: {
         # Make sure that deployment_id is not empty
         test -z "$(grep "test--end" /config)"
         """#
-    }
+	}
 }
 
 TestDeploy: {
 	// Generate some random
-	genRandom1: bl.BashScript & {
+	genRandom1: bl.#BashScript & {
 		runPolicy: "always"
 		code: """
 		echo -n $RANDOM > /rand
@@ -77,8 +76,7 @@ TestDeploy: {
 		output: "/rand": string
 	}
 
-
-	genRandom2: bl.BashScript & {
+	genRandom2: bl.#BashScript & {
 		runPolicy: "always"
 		code: """
 		echo -n $RANDOM > /rand
@@ -89,7 +87,7 @@ TestDeploy: {
 	random1: genRandom1.output["/rand"]
 	random2: genRandom2.output["/rand"]
 
-    kubeCfgString : #"""
+	kubeCfgString: #"""
         apiVersion: v1
         kind: Pod
         metadata:
@@ -101,9 +99,9 @@ TestDeploy: {
                   image: hello-world
         """#
 
-    kubeCfgDirectory: file.Create & {
-        filename: "/test.yaml"
-        contents : #"""
+	kubeCfgDirectory: file.#Create & {
+		filename: "/test.yaml"
+		contents: #"""
             apiVersion: v1
             kind: Pod
             metadata:
@@ -114,24 +112,24 @@ TestDeploy: {
                     - name: test
                       image: hello-world
             """#
-    }
+	}
 
-    authenticate: eks.KubeConfig & {
-        config: TestConfig.awsConfig
-        cluster: TestConfig.eksClusterName
-    }
+	authenticate: eks.#KubeConfig & {
+		config:  TestConfig.awsConfig
+		cluster: TestConfig.eksClusterName
+	}
 
-    deployString: Deploy & {
-        kubeconfig: authenticate.kubeconfig
-        namespace: "stackbrew-test"
-        source: kubeCfgString
-        prune: false
-    }
+	deployString: #Deploy & {
+		kubeconfig: authenticate.kubeconfig
+		namespace:  "stackbrew-test"
+		source:     kubeCfgString
+		prune:      false
+	}
 
-    deployDirectory: Deploy & {
-        kubeconfig: authenticate.kubeconfig
-        namespace: "stackbrew-test"
-        source: kubeCfgDirectory.result
-        prune: false
-    }
+	deployDirectory: #Deploy & {
+		kubeconfig: authenticate.kubeconfig
+		namespace:  "stackbrew-test"
+		source:     kubeCfgDirectory.result
+		prune:      false
+	}
 }

--- a/pkg/kubernetes/kubernetes.cue
+++ b/pkg/kubernetes/kubernetes.cue
@@ -5,9 +5,9 @@ import (
 )
 
 // Exposes `kubectl kustomize`
-Kustomize :: {
+#Kustomize: {
 	// Kubernetes config to take as input
-	source: string | bl.Directory
+	source: string | bl.#Directory
 
 	// Optionnal kustomization.yaml
 	kustomization: *"" | string
@@ -18,7 +18,7 @@ Kustomize :: {
 	// Output of kustomize
 	out: kustomize.output["/kube/out"]
 
-	kustomize: bl.BashScript & {
+	kustomize: bl.#BashScript & {
 		input: {
 			"/kube/source":             source
 			"/kube/kustomization.yaml": kustomization
@@ -45,9 +45,10 @@ Kustomize :: {
 }
 
 // Apply a Kubernetes configuration
-Apply :: {
+
+#Apply: {
 	// Kubernetes config to deploy
-	source: string | bl.Directory
+	source: string | bl.#Directory
 
 	// Kubernetes Namespace to deploy to
 	namespace: string
@@ -56,9 +57,9 @@ Apply :: {
 	version: *"v1.14.7" | string
 
 	// Kube config file
-	kubeconfig: bl.Secret
+	kubeconfig: bl.#Secret
 
-	deploy: bl.BashScript & {
+	deploy: bl.#BashScript & {
 		runPolicy: "always"
 
 		input: {

--- a/pkg/kubernetes/kubernetes_test.cue
+++ b/pkg/kubernetes/kubernetes_test.cue
@@ -2,19 +2,19 @@ package kubernetes
 
 import (
 	"blocklayer.dev/bl"
-    "encoding/yaml"
+	"encoding/yaml"
 	"blocklayer.dev/aws"
 	"blocklayer.dev/aws/eks"
 )
 
 TestConfig: {
-	awsConfig:     aws.Config
-    eksClusterName: string
+	awsConfig:      aws.#Config
+	eksClusterName: string
 }
 
 TestEKS: {
 	// Generate some random
-	genRandom: bl.BashScript & {
+	genRandom: bl.#BashScript & {
 		runPolicy: "always"
 		code: """
 		echo -n $RANDOM > /rand
@@ -24,17 +24,17 @@ TestEKS: {
 
 	random: genRandom.output["/rand"]
 
-    // Authenticate against EKS
-    authenticate: eks.KubeConfig & {
-        config: TestConfig.awsConfig
-        cluster: TestConfig.eksClusterName
-    }
+	// Authenticate against EKS
+	authenticate: eks.#KubeConfig & {
+		config:  TestConfig.awsConfig
+		cluster: TestConfig.eksClusterName
+	}
 
-    // Deploy a dummy inline config
-    deployString: Apply & {
-        kubeconfig: authenticate.kubeconfig
-        namespace: "stackbrew-test"
-        source: #"""
+	// Deploy a dummy inline config
+	deployString: #Apply & {
+		kubeconfig: authenticate.kubeconfig
+		namespace:  "stackbrew-test"
+		source:     #"""
             apiVersion: v1
             kind: Pod
             metadata:
@@ -45,35 +45,35 @@ TestEKS: {
                     - name: test
                       image: hello-world
             """#
-    }
+	}
 
-    deployDirectory: Apply & {
-        kubeconfig: authenticate.kubeconfig
-        namespace: "stackbrew-test"
-        source: bl.Directory & {
-            source: "context://testdata"
-        }
-    }
+	deployDirectory: #Apply & {
+		kubeconfig: authenticate.kubeconfig
+		namespace:  "stackbrew-test"
+		source:     bl.#Directory & {
+			source: "context://testdata"
+		}
+	}
 }
 
 TestKustomize: {
-    kubeConfig: Kustomize & {
-        source: bl.Directory & {
-            source: "context://testdata"
-        }
-        kustomization: yaml.Marshal({
-            resources: ["test.yaml"]
-            images: [{
-                name: "hello-world"
-                newTag: "linux"
-            }]
-        })
-    }
+	kubeConfig: #Kustomize & {
+		source: bl.#Directory & {
+			source: "context://testdata"
+		}
+		kustomization: yaml.Marshal({
+			resources: ["test.yaml"]
+			images: [{
+				name:   "hello-world"
+				newTag: "linux"
+			}]
+		})
+	}
 
-    changeImageName: bl.BashScript & {
+	changeImageName: bl.#BashScript & {
 		runPolicy: "always"
 
-        input: "/kube/config.yaml": kubeConfig.out
+		input: "/kube/config.yaml": kubeConfig.out
 
 		code: """
         grep hello-world:linux /kube/config.yaml

--- a/pkg/mysql/mysql.cue
+++ b/pkg/mysql/mysql.cue
@@ -1,12 +1,11 @@
 package mysql
 
-Database :: {
+#Database: {
 	name:   string
 	create: *true | bool
-	server: Server
+	server: #Server
 }
-
-Server :: {
+#Server: {
 	host:          string
 	port:          *3306 | int
 	adminUser:     string

--- a/pkg/netlify/netlify.cue
+++ b/pkg/netlify/netlify.cue
@@ -7,22 +7,22 @@ import (
 )
 
 // A Netlify account
-Account :: {
+#Account: {
 	// Use this Netlify account name
 	// (also referred to as "team" in the Netlify docs)
 	name: string | *""
 
 	// Netlify authentication token
-	token: bl.Secret
+	token: bl.#Secret
 }
 
 // A Netlify site
-Site :: {
+#Site: {
 	// Netlify account this site is attached to
-	account: Account
+	account: #Account
 
 	// Contents of the application to deploy
-	contents: bl.Directory
+	contents: bl.#Directory
 
 	// Deploy to this Netlify site
 	name: string
@@ -36,7 +36,7 @@ Site :: {
 	// Deployment url
 	url: strings.TrimRight(deploy.output["/info/url"], "\n")
 
-	deploy: bl.BashScript & {
+	deploy: bl.#BashScript & {
 		runPolicy: "always"
 
 		workdir: "/site/contents"

--- a/pkg/ssh/ssh.cue
+++ b/pkg/ssh/ssh.cue
@@ -6,7 +6,7 @@ import (
 )
 
 // A SSH endpoint
-Endpoint :: {
+#Endpoint: {
 	// Endpoint hostname
 	host: string
 
@@ -17,17 +17,17 @@ Endpoint :: {
 	user: string
 
 	// Endpoint private key
-	key: bl.Secret
+	key: bl.#Secret
 
 	// Run a command remotely on this endpoint
-	RunCommand :: {
+	#RunCommand: {
 		cmd: [...string]
 		stdout: output["/output/stdout"]
 		stderr: output["/output/stderr"]
 
 		output: _
 
-		bl.BashScript & {
+		bl.#BashScript & {
 			input: {
 				"/key": key
 			}

--- a/pkg/yarn/yarn.cue
+++ b/pkg/yarn/yarn.cue
@@ -7,9 +7,9 @@ import (
 )
 
 // A javascript application built by Yarn
-App :: {
+#App: {
 	// Source code of the javascript application
-	source: bl.Directory
+	source: bl.#Directory
 
 	// Load the contents of `environment` into the yarn process?
 	loadEnv: bool | *true
@@ -29,7 +29,7 @@ App :: {
 	buildDirectory: string | *"build"
 
 	// Execute this script to build the app
-	action: build: bl.BashScript & {
+	action: build: bl.#BashScript & {
 		code: """
 			yarn install --network-timeout 1000000
 			yarn run "$YARN_BUILD_SCRIPT"
@@ -50,13 +50,13 @@ App :: {
 		input: {
 			"/app/src": source
 			// FIXME: set a cache key?
-			"/cache/yarn": bl.Cache
+			"/cache/yarn": bl.#Cache
 			if writeEnvFile != "" {
-				"/app/src/\(writeEnvFile)": strings.Join([ for k, v in appEnv { "\(k)=\(v)" } ], "\n")
+				"/app/src/\(writeEnvFile)": strings.Join([ for k, v in appEnv {"\(k)=\(v)"}], "\n")
 			}
 		}
 
-		output: "/app/build": bl.Directory
+		output: "/app/build": bl.#Directory
 
 		os: package: {
 			rsync: true

--- a/pkg/yarn/yarn_test.cue
+++ b/pkg/yarn/yarn_test.cue
@@ -2,14 +2,14 @@ package yarn
 
 import "blocklayer.dev/bl"
 
-TestYarn : {
-	run: App & {
-		source: bl.Directory & {
+TestYarn: {
+	run: #App & {
+		source: bl.#Directory & {
 			source: "context://testdata/src"
 		}
 	}
 
-	test: bl.BashScript & {
+	test: bl.#BashScript & {
 		input: "/build": run.build
 		code: """
         test "$(cat /build/test)" = "output"
@@ -17,9 +17,9 @@ TestYarn : {
 	}
 }
 
-TestYarnEnvFile : {
-	run: App & {
-		source: bl.Directory & {
+TestYarnEnvFile: {
+	run: #App & {
+		source: bl.#Directory & {
 			source: "context://testdata/src"
 		}
 		loadEnv: true
@@ -27,7 +27,7 @@ TestYarnEnvFile : {
 		writeEnvFile: ".env"
 	}
 
-	test: bl.BashScript & {
+	test: bl.#BashScript & {
 		input: "/build": run.build
 		code: """
         grep "FOO=BAR" /build/.env

--- a/pkg/zip/zip.cue
+++ b/pkg/zip/zip.cue
@@ -3,21 +3,21 @@ package zip
 import "blocklayer.dev/bl"
 
 // Zip archive
-Archive :: {
+#Archive: {
 
 	// Source Directory, File or String to Zip from
-	source: bl.Directory | string
+	source: bl.#Directory | string
 
 	// Archive file output
-	archive: bl.Directory & {
+	archive: bl.#Directory & {
 		source: run.output["/outputs/out"]
 		path:   "file.zip"
 	}
 
-	run: bl.BashScript & {
+	run: bl.#BashScript & {
 		input: "/inputs/source": source
 
-		output: "/outputs/out": bl.Directory
+		output: "/outputs/out": bl.#Directory
 
 		os: package: zip: true
 


### PR DESCRIPTION
This modifies all packages to use the new definition syntax used in Cue 0.2 `#Foo:` instead of the old syntax used in cue 0.1 `Foo ::`.

All tests pass. Note that this will break configurations that reference definitions in any Stackbrew package.

For example if this configuration:

```
import "blocklayer.dev/file"

f: file.Create
```

will need to be changed to:

```
import "blocklayer.dev/file"

f: file.#Create
```